### PR TITLE
修复 makefile 因 web/public 目录缺失导致构建失败

### DIFF
--- a/makefile
+++ b/makefile
@@ -97,6 +97,7 @@ build-vue:
 	cd web/vue && yarn install
 	@echo "Building Vue frontend..."
 	cd web/vue && yarn run build
+	mkdir -p web/public
 	cp -r web/vue/dist/* web/public/
 
 .PHONY: install-vue


### PR DESCRIPTION
由于 Git 不跟踪空目录，web/public 在提交 cf94b21b1421fce03ab9854a071edb58650a0146 中被移除
这导致 `make build-vue` 出现错误：
```
cp -r web/vue/dist/* web/public/
cp: target 'web/public/' is not a directory
make: *** [makefile:100: build-vue] Error 1
```

本次修改在复制文件前，通过 `mkdir -p web/public` 确保目标目录存在