### PR TITLE
为任务节点添加必填标识

### DIFF
--- a/web/vue/src/pages/task/edit.vue
+++ b/web/vue/src/pages/task/edit.vue
@@ -440,6 +440,7 @@ export default {
           {required: true, message: this.t('message.pleaseEnterNotifyKeyword'), trigger: 'blur'}
         ],
         host_ids: [
+          {required: true, message: this.t('message.selectTaskNode'), trigger: 'blur'},
           {validator: (rule, value, callback) => this.validateHostIds(rule, value, callback), trigger: 'change'}
         ]
       }


### PR DESCRIPTION
此前，在创建新任务时，尽管“任务节点”字段为必填项，但前端界面并没有为其添加必填标识。本次修改将在前端界面为其添加必填标识