### PR TITLE
fix: use smallint instead of tinyint for PostgreSQL compatibility

### DIFF
--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -70,28 +70,28 @@ func (t *NextRunTime) UnmarshalJSON(data []byte) error {
 type Task struct {
 	Id               int                  `json:"id" gorm:"primaryKey;autoIncrement"`
 	Name             string               `json:"name" gorm:"type:varchar(32);not null"`
-	Level            TaskLevel            `json:"level" gorm:"type:tinyint;not null;index;default:1"`
+	Level            TaskLevel            `json:"level" gorm:"smallint;not null;index;default:1"`
 	DependencyTaskId string               `json:"dependency_task_id" gorm:"type:varchar(64);not null;default:''"`
-	DependencyStatus TaskDependencyStatus `json:"dependency_status" gorm:"type:tinyint;not null;default:1"`
+	DependencyStatus TaskDependencyStatus `json:"dependency_status" gorm:"smallint;not null;default:1"`
 	Spec             string               `json:"spec" gorm:"type:varchar(64);not null"`
-	Protocol         TaskProtocol         `json:"protocol" gorm:"type:tinyint;not null;index"`
+	Protocol         TaskProtocol         `json:"protocol" gorm:"smallint;not null;index"`
 	Command          string               `json:"command" gorm:"type:text;not null"`
-	HttpMethod       TaskHTTPMethod       `json:"http_method" gorm:"type:tinyint;not null;default:1"`
+	HttpMethod       TaskHTTPMethod       `json:"http_method" gorm:"smallint;not null;default:1"`
 	HttpBody         string               `json:"http_body" gorm:"type:text"`
 	HttpHeaders      string               `json:"http_headers" gorm:"type:text"`
 	SuccessPattern   string               `json:"success_pattern" gorm:"type:varchar(512);not null;default:''"`
 	Timeout          int                  `json:"timeout" gorm:"type:mediumint;not null;default:0"`
-	Multi            int8                 `json:"multi" gorm:"type:tinyint;not null;default:0"`
-	RetryTimes       int8                 `json:"retry_times" gorm:"type:tinyint;not null;default:0"`
+	Multi            int8                 `json:"multi" gorm:"smallint;not null;default:0"`
+	RetryTimes       int8                 `json:"retry_times" gorm:"smallint;not null;default:0"`
 	RetryInterval    int16                `json:"retry_interval" gorm:"type:smallint;not null;default:0"`
-	NotifyStatus     int8                 `json:"notify_status" gorm:"type:tinyint;not null;default:0"`
-	NotifyType       int8                 `json:"notify_type" gorm:"type:tinyint;not null;default:0"`
+	NotifyStatus     int8                 `json:"notify_status" gorm:"smallint;not null;default:0"`
+	NotifyType       int8                 `json:"notify_type" gorm:"smallint;not null;default:0"`
 	NotifyReceiverId string               `json:"notify_receiver_id" gorm:"type:varchar(256);not null;default:''"`
 	NotifyKeyword    string               `json:"notify_keyword" gorm:"type:varchar(128);not null;default:''"`
 	Tag              string               `json:"tag" gorm:"type:varchar(255);not null;default:''"`
 	LogRetentionDays int                  `json:"log_retention_days" gorm:"type:smallint;not null;default:0"`
 	Remark           string               `json:"remark" gorm:"type:varchar(100);not null;default:''"`
-	Status           Status               `json:"status" gorm:"type:tinyint;not null;index;default:0"`
+	Status           Status               `json:"status" gorm:"smallint;not null;index;default:0"`
 	CreatedAt        time.Time            `json:"created" gorm:"column:created;autoCreateTime"`
 	DeletedAt        *time.Time           `json:"deleted" gorm:"column:deleted;index"`
 	BaseModel        `json:"-" gorm:"-"`

--- a/internal/models/task_log.go
+++ b/internal/models/task_log.go
@@ -49,14 +49,14 @@ type TaskLog struct {
 	TaskId     int          `json:"task_id" gorm:"not null;index;default:0"`
 	Name       string       `json:"name" gorm:"type:varchar(32);not null"`
 	Spec       string       `json:"spec" gorm:"type:varchar(64);not null"`
-	Protocol   TaskProtocol `json:"protocol" gorm:"type:tinyint;not null;index"`
+	Protocol   TaskProtocol `json:"protocol" gorm:"smallint;not null;index"`
 	Command    string       `json:"command" gorm:"type:varchar(256);not null"`
 	Timeout    int          `json:"timeout" gorm:"type:mediumint;not null;default:0"`
-	RetryTimes int8         `json:"retry_times" gorm:"type:tinyint;not null;default:0"`
+	RetryTimes int8         `json:"retry_times" gorm:"smallint;not null;default:0"`
 	Hostname   string       `json:"hostname" gorm:"type:varchar(128);not null;default:''"`
 	StartTime  LocalTime    `json:"start_time" gorm:"column:start_time;autoCreateTime"`
 	EndTime    LocalTime    `json:"end_time" gorm:"column:end_time;autoUpdateTime"`
-	Status     Status       `json:"status" gorm:"type:tinyint;not null;index;default:1"`
+	Status     Status       `json:"status" gorm:"smallint;not null;index;default:1"`
 	Result     string       `json:"result" gorm:"type:mediumtext;not null"`
 	TotalTime  int          `json:"total_time" gorm:"-"`
 	BaseModel  `json:"-" gorm:"-"`

--- a/internal/models/task_template.go
+++ b/internal/models/task_template.go
@@ -13,24 +13,24 @@ type TaskTemplate struct {
 	Name             string    `json:"name" gorm:"type:varchar(64);not null"`
 	Description      string    `json:"description" gorm:"type:varchar(500);not null;default:''"`
 	Category         string    `json:"category" gorm:"type:varchar(32);not null;default:'custom';index"`
-	Protocol         int8      `json:"protocol" gorm:"type:tinyint;not null;default:2"`
+	Protocol         int8      `json:"protocol" gorm:"smallint;not null;default:2"`
 	Command          string    `json:"command" gorm:"type:text;not null"`
-	HttpMethod       int8      `json:"http_method" gorm:"type:tinyint;not null;default:1"`
+	HttpMethod       int8      `json:"http_method" gorm:"smallint;not null;default:1"`
 	HttpBody         string    `json:"http_body" gorm:"type:text"`
 	HttpHeaders      string    `json:"http_headers" gorm:"type:text"`
 	SuccessPattern   string    `json:"success_pattern" gorm:"type:varchar(512);not null;default:''"`
 	Tag              string    `json:"tag" gorm:"type:varchar(255);not null;default:''"`
 	Spec             string    `json:"spec" gorm:"type:varchar(64);not null;default:''"`
 	Timeout          int       `json:"timeout" gorm:"type:int;not null;default:0"`
-	Multi            int8      `json:"multi" gorm:"type:tinyint;not null;default:1"`
-	RetryTimes       int8      `json:"retry_times" gorm:"type:tinyint;not null;default:0"`
+	Multi            int8      `json:"multi" gorm:"smallint;not null;default:1"`
+	RetryTimes       int8      `json:"retry_times" gorm:"smallint;not null;default:0"`
 	RetryInterval    int16     `json:"retry_interval" gorm:"type:smallint;not null;default:0"`
 	Timezone         string    `json:"timezone" gorm:"type:varchar(64);not null;default:''"`
-	NotifyStatus     int8      `json:"notify_status" gorm:"type:tinyint;not null;default:0"`
-	NotifyType       int8      `json:"notify_type" gorm:"type:tinyint;not null;default:0"`
+	NotifyStatus     int8      `json:"notify_status" gorm:"smallint;not null;default:0"`
+	NotifyType       int8      `json:"notify_type" gorm:"smallint;not null;default:0"`
 	NotifyKeyword    string    `json:"notify_keyword" gorm:"type:varchar(128);not null;default:''"`
 	LogRetentionDays int       `json:"log_retention_days" gorm:"type:smallint;not null;default:0"`
-	IsBuiltin        int8      `json:"is_builtin" gorm:"type:tinyint;not null;default:0"`
+	IsBuiltin        int8      `json:"is_builtin" gorm:"smallint;not null;default:0"`
 	UsageCount       int       `json:"usage_count" gorm:"type:int;not null;default:0"`
 	CreatedBy        string    `json:"created_by" gorm:"type:varchar(64);not null;default:''"`
 	CreatedAt        time.Time `json:"created_at" gorm:"column:created_at;autoCreateTime"`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -16,11 +16,11 @@ type User struct {
 	Salt         string    `json:"-" gorm:"type:char(6);not null"`
 	Email        string    `json:"email" gorm:"type:varchar(50);not null;uniqueIndex;default:''"`
 	TwoFactorKey string    `json:"-" gorm:"column:two_factor_key;type:varchar(100);default:''"`
-	TwoFactorOn  int8      `json:"two_factor_on" gorm:"column:two_factor_on;type:tinyint;not null;default:0"`
+	TwoFactorOn  int8      `json:"two_factor_on" gorm:"column:two_factor_on;smallint;not null;default:0"`
 	CreatedAt    time.Time `json:"created" gorm:"column:created;autoCreateTime"`
 	UpdatedAt    time.Time `json:"updated" gorm:"column:updated;autoUpdateTime"`
-	IsAdmin      int8      `json:"is_admin" gorm:"type:tinyint;not null;default:0"`
-	Status       Status    `json:"status" gorm:"type:tinyint;not null;default:1"`
+	IsAdmin      int8      `json:"is_admin" gorm:"smallint;not null;default:0"`
+	Status       Status    `json:"status" gorm:"smallint;not null;default:1"`
 	BaseModel    `json:"-" gorm:"-"`
 }
 


### PR DESCRIPTION
## Problem



When using PostgreSQL as the database, gocron v1.6.0 fails during `AutoMigrate` on the `task_template` table with:



ERROR: type "tinyint" does not exist (SQLSTATE 42704)

This is because all GORM model tags hardcode `type:tinyint`, which is a MySQL-specific type not supported by PostgreSQL.

## Solution

Changed all `type:tinyint` GORM tags to `type:smallint` across 4 model files:

- `internal/models/task.go` (9 fields)
- `internal/models/task_template.go` (7 fields)
- `internal/models/task_log.go` (3 fields)
- `internal/models/user.go` (3 fields)

`smallint` is a standard SQL type supported by MySQL, PostgreSQL, and SQLite, and its range (-32,768 to 32,767) fully covers Go `int8` values (-128 to 127).

## Verification

- `go vet ./internal/models/...` — pass
- `go test -race ./internal/models/...` — pass
- `go build ./...` — pass

Fixes #161