### PR TITLE
fix(build): fix local build and cross-compilation (package.sh + frontend)

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -197,7 +197,7 @@ run() {
 
 package_gocron() {
     BINARY_NAME='gocron'
-    MAIN_FILE="./cmd/gocron/gocron.go"
+    MAIN_FILE="./cmd/gocron"
     INCLUDE_FILE=()
 
     run
@@ -205,7 +205,7 @@ package_gocron() {
 
 package_gocron_node() {
     BINARY_NAME='gocron-node'
-    MAIN_FILE="./cmd/node/node.go"
+    MAIN_FILE="./cmd/node"
     INCLUDE_FILE=()
 
     run

--- a/web/gocronx-admin/package.json
+++ b/web/gocronx-admin/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "dev": "vite --open",
-    "build": "vue-tsc --noEmit && vite build",
+    "build": "vite build && vue-tsc --noEmit",
     "build-only": "vite build",
     "serve": "vite preview",
     "lint": "eslint",


### PR DESCRIPTION
## Summary

修复本地 `make build-admin` 和 `make package-*` 无法正常构建的问题。

## Changes

### 1. package.sh — 交叉编译失败

`go build` 传入单文件路径（`./cmd/gocron/gocron.go`）时不会自动包含同包下其他 `.go` 文件中的符号，导致 `resetPasswordCommand`、`taskCommand`、`statsCommand` 等函数 undefined。

改为包目录路径（`./cmd/gocron`），与 `.goreleaser.yml` 中 `main: ./cmd/gocron` 的写法一致。

### 2. frontend build 脚本 — vue-tsc 类型检查失败

`unplugin-auto-import` 的类型声明文件（`auto-imports.d.ts`、`components.d.ts`）在 `vite build` 运行时才会生成。原脚本 `vue-tsc --noEmit && vite build` 先执行 `vue-tsc` 时找不到这些类型声明，导致大量 `TS2304: Cannot find name` 错误。

调整顺序为 `vite build && vue-tsc --noEmit`，与 CI workflow 中的流程一致。

## Test plan

- [x] `make build-admin` 构建前端
- [x] `make package-windows` 交叉编译 Windows 包