### PR TITLE
feat: add Termux (Android) support — bash path detection, temp dir, cross-compilation

### DIFF
--- a/internal/modules/utils/utils_unix.go
+++ b/internal/modules/utils/utils_unix.go
@@ -21,6 +21,17 @@ type Result struct {
 	err    error
 }
 
+// detectBashPath 根据当前系统环境检测 bash 路径。
+// Termux (Android) 下 bash 位于 /data/data/com.termux/files/usr/bin/bash，
+// 标准 Linux / macOS 下为 /bin/bash。
+func detectBashPath() string {
+	termuxBash := "/data/data/com.termux/files/usr/bin/bash"
+	if _, err := os.Stat(termuxBash); err == nil {
+		return termuxBash
+	}
+	return "/bin/bash"
+}
+
 // 执行shell命令，可设置执行超时时间
 // 改进：将命令写入临时脚本执行，即使超时或被取消，也会返回已产生的输出
 func ExecShell(ctx context.Context, command string) (string, error) {
@@ -29,8 +40,8 @@ func ExecShell(ctx context.Context, command string) (string, error) {
 	// 将换行符统一替换为Unix风格的\n
 	command = strings.ReplaceAll(command, "\r\n", "\n")
 
-	// 创建临时文件来存储命令，按照指定格式命名
-	tmpDir := "/tmp"
+	// 使用系统临时目录
+	tmpDir := os.TempDir()
 	timestamp := time.Now().Format("20060102150405")
 	scriptPattern := fmt.Sprintf("gocron_%s_*.sh", timestamp)
 
@@ -59,9 +70,10 @@ func ExecShell(ctx context.Context, command string) (string, error) {
 		return "", fmt.Errorf("设置脚本执行权限失败: %w", err)
 	}
 
-	// 使用 /bin/bash 命令执行脚本文件
+	// 根据当前系统环境检测 bash 路径，执行脚本文件
 	scriptPath := tmpFile.Name()
-	cmd := exec.Command("/bin/bash", scriptPath)
+	bashPath := detectBashPath()
+	cmd := exec.Command(bashPath, scriptPath)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}

--- a/internal/modules/utils/utils_unix.go
+++ b/internal/modules/utils/utils_unix.go
@@ -4,10 +4,12 @@
 package utils
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -21,13 +23,85 @@ type Result struct {
 	err    error
 }
 
+// isTermux 通过检查 Termux 标志文件判断当前是否运行在 Termux (Android) 环境下。
+// 该文件是 Termux 安装后必定存在的，比检查 PREFIX 环境变量更可靠。
+func isTermux() bool {
+	_, err := os.Stat("/data/data/com.termux/files/usr/etc/termux")
+	return err == nil
+}
+
+// termuxPrefix 返回 Termux 的安装前缀路径。
+func termuxPrefix() string {
+	return "/data/data/com.termux/files/usr"
+}
+
+// init 在包加载时处理 Termux/Android 的 DNS 和 TLS CA 证书适配。
+func init() {
+	if !isTermux() {
+		return
+	}
+
+	// DNS：Termux 没有 /etc/resolv.conf，通过自定义 Resolver 接管 DNS 解析。
+	// 如果用户安装了 resolv.conf 则读取其中的 nameserver，否则使用 114.114.114.114。
+	resolvPath := termuxPrefix() + "/etc/resolv.conf"
+	dnsAddr := readResolvConfDNS(resolvPath)
+	net.DefaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, dnsAddr)
+		},
+	}
+
+	// TLS CA：Termux 下没有标准 CA 证书路径，设置 SSL_CERT_FILE 指向 Termux 证书
+	setTermuxCACerts()
+}
+
+// readResolvConfDNS 解析 resolv.conf 文件，提取第一个 nameserver 并返回 ip:53。
+// 文件不存在或解析失败则回退到 114.114.114.114:53。
+func readResolvConfDNS(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return "114.114.114.114:53"
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if after, ok := strings.CutPrefix(line, "nameserver"); ok {
+			addr := strings.TrimSpace(after)
+			if addr != "" {
+				return net.JoinHostPort(addr, "53")
+			}
+		}
+	}
+	return "114.114.114.114:53"
+}
+
+// setTermuxCACerts 查找 Termux 的 CA 证书文件并设置 SSL_CERT_FILE 环境变量。
+// Go 的 crypto/x509 包读取该变量以加载 CA 证书池。
+func setTermuxCACerts() {
+	prefix := termuxPrefix()
+	paths := []string{
+		prefix + "/etc/tls/cert.pem",
+		prefix + "/etc/tls/ca-bundle.pem",
+		prefix + "/etc/ssl/certs/ca-certificates.crt",
+	}
+
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			_ = os.Setenv("SSL_CERT_FILE", p)
+			return
+		}
+	}
+}
+
 // detectBashPath 根据当前系统环境检测 bash 路径。
-// Termux (Android) 下 bash 位于 /data/data/com.termux/files/usr/bin/bash，
-// 标准 Linux / macOS 下为 /bin/bash。
+// Termux (Android) 下 bash 位于 termuxPrefix/bin/bash，标准 Linux / macOS 下为 /bin/bash。
 func detectBashPath() string {
-	termuxBash := "/data/data/com.termux/files/usr/bin/bash"
-	if _, err := os.Stat(termuxBash); err == nil {
-		return termuxBash
+	if isTermux() {
+		return termuxPrefix() + "/bin/bash"
 	}
 	return "/bin/bash"
 }

--- a/internal/modules/utils/utils_unix_test.go
+++ b/internal/modules/utils/utils_unix_test.go
@@ -40,16 +40,25 @@ func TestDetectBashPath(t *testing.T) {
 	}
 }
 
+func TestIsTermux(t *testing.T) {
+	result := isTermux()
+	if result {
+		// isTermux 返回 true 时，标志文件必须存在
+		if _, err := os.Stat("/data/data/com.termux/files/usr/etc/termux"); err != nil {
+			t.Fatal("isTermux returns true but termux marker doesn't exist")
+		}
+	}
+}
+
 func TestDetectBashPathTermux(t *testing.T) {
-	// 若 Termux bash 文件存在，则 detectBashPath 应返回 Termux 路径
-	termuxBash := "/data/data/com.termux/files/usr/bin/bash"
-	if _, err := os.Stat(termuxBash); err != nil {
+	if !isTermux() {
 		t.Skip("Not running on Termux, skipping")
 	}
 
 	path := detectBashPath()
-	if path != termuxBash {
-		t.Fatalf("On Termux, expected %s, got: %s", termuxBash, path)
+	expected := termuxPrefix() + "/bin/bash"
+	if path != expected {
+		t.Fatalf("On Termux, expected %s, got: %s", expected, path)
 	}
 }
 
@@ -73,6 +82,68 @@ func TestExecShellUsesTempDir(t *testing.T) {
 		if strings.HasPrefix(entry.Name(), "gocron_") && strings.HasSuffix(entry.Name(), ".sh") {
 			t.Fatalf("Temporary script file was not cleaned up: %s", filepath.Join(tempDir, entry.Name()))
 		}
+	}
+}
+
+func TestReadResolvConfDNS(t *testing.T) {
+	f, err := os.CreateTemp("", "resolv.conf.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	content := "# comment\nnameserver 1.2.3.4\nnameserver 5.6.7.8\n"
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	addr := readResolvConfDNS(f.Name())
+	if addr != "1.2.3.4:53" {
+		t.Fatalf("Expected 1.2.3.4:53, got: %s", addr)
+	}
+}
+
+func TestReadResolvConfDNSEmpty(t *testing.T) {
+	f, err := os.CreateTemp("", "resolv.conf.*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.Close()
+
+	// 文件为空时回退到默认 DNS
+	addr := readResolvConfDNS(f.Name())
+	if addr != "114.114.114.114:53" {
+		t.Fatalf("Expected fallback 114.114.114.114:53, got: %s", addr)
+	}
+}
+
+func TestTermuxPrefix(t *testing.T) {
+	prefix := termuxPrefix()
+	if prefix != "/data/data/com.termux/files/usr" {
+		t.Fatalf("Expected fixed Termux prefix, got: %s", prefix)
+	}
+	if isTermux() {
+		if _, err := os.Stat(prefix); err != nil {
+			t.Fatalf("Termux prefix %s should exist when isTermux is true: %v", prefix, err)
+		}
+	}
+}
+
+func TestSetTermuxCACerts(t *testing.T) {
+	if !isTermux() {
+		t.Skip("Not running on Termux, skipping")
+	}
+
+	// 手动触发以确保 init 之后的状态一致
+	setTermuxCACerts()
+	certFile := os.Getenv("SSL_CERT_FILE")
+	if certFile == "" {
+		t.Fatal("Expected SSL_CERT_FILE to be set on Termux")
+	}
+	if _, err := os.Stat(certFile); err != nil {
+		t.Fatalf("SSL_CERT_FILE %s does not exist: %v", certFile, err)
 	}
 }
 

--- a/internal/modules/utils/utils_unix_test.go
+++ b/internal/modules/utils/utils_unix_test.go
@@ -5,10 +5,76 @@ package utils
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestDetectBashPath(t *testing.T) {
+	path := detectBashPath()
+	if path == "" {
+		t.Fatal("Expected non-empty bash path")
+	}
+
+	// 验证返回的路径是 Termux 或标准 Linux/macOS 的合法 bash 路径
+	validPaths := []string{
+		"/data/data/com.termux/files/usr/bin/bash",
+		"/bin/bash",
+	}
+	found := false
+	for _, p := range validPaths {
+		if path == p {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Expected bash path to be one of %v, got: %s", validPaths, path)
+	}
+
+	// 验证返回的 bash 路径文件存在
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("Bash path %s does not exist: %v", path, err)
+	}
+}
+
+func TestDetectBashPathTermux(t *testing.T) {
+	// 若 Termux bash 文件存在，则 detectBashPath 应返回 Termux 路径
+	termuxBash := "/data/data/com.termux/files/usr/bin/bash"
+	if _, err := os.Stat(termuxBash); err != nil {
+		t.Skip("Not running on Termux, skipping")
+	}
+
+	path := detectBashPath()
+	if path != termuxBash {
+		t.Fatalf("On Termux, expected %s, got: %s", termuxBash, path)
+	}
+}
+
+func TestExecShellUsesTempDir(t *testing.T) {
+	ctx := context.Background()
+	output, err := ExecShell(ctx, "echo 'hello world'")
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if !strings.Contains(output, "hello world") {
+		t.Fatalf("Expected output to contain 'hello world', got: %s", output)
+	}
+
+	// 检查临时目录中没有遗留的脚本文件
+	tempDir := os.TempDir()
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to read temp dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "gocron_") && strings.HasSuffix(entry.Name(), ".sh") {
+			t.Fatalf("Temporary script file was not cleaned up: %s", filepath.Join(tempDir, entry.Name()))
+		}
+	}
+}
 
 func TestExecShellSuccess(t *testing.T) {
 	ctx := context.Background()

--- a/makefile
+++ b/makefile
@@ -84,10 +84,15 @@ package-windows: build-web
 	@echo "Building packages for Windows..."
 	bash ./package.sh -p windows -a "amd64"
 
+.PHONY: package-termux
+package-termux: build-web
+	@echo "Building packages for Termux (Android)..."
+	bash ./package.sh -p android -a "amd64,arm64"
+
 .PHONY: package-all
 package-all: build-web
 	@echo "Building packages for all platforms..."
-	bash ./package.sh -p "linux,darwin" -a "amd64,arm64"
+	bash ./package.sh -p "linux,darwin,android" -a "amd64,arm64"
 	bash ./package.sh -p "windows" -a "amd64"
 
 # 前端构建（gocronx-admin）

--- a/package.sh
+++ b/package.sh
@@ -33,7 +33,8 @@ DEFAULT_OS=${GOHOSTOS}
 # 未指定ARCH,默认值
 DEFAULT_ARCH=${GOHOSTARCH}
 # 支持的系统
-SUPPORT_OS=(linux darwin windows)
+# android 编译时映射到 GOOS=linux（Termux 提供 Linux 用户空间）
+SUPPORT_OS=(linux darwin windows android)
 # 支持的架构
 SUPPORT_ARCH=(386 amd64 arm64)
  
@@ -130,8 +131,14 @@ build() {
                 FILENAME=${BINARY_NAME}
             fi
 
+            # android 映射到 linux（Termux 提供 Linux 用户空间）
+            local BUILD_OS="${OS}"
+            if [[ "${OS}" = "android" ]]; then
+                BUILD_OS="linux"
+            fi
+
             print_message "编译 ${BINARY_NAME} ${OS}-${ARCH} 版本"
-            env CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -o ${BUILD_DIR}/${BINARY_NAME}-${OS}-${ARCH}/${FILENAME} ${MAIN_FILE}
+            env CGO_ENABLED=0 GOOS=${BUILD_OS} GOARCH=${ARCH} go build -ldflags "${LDFLAGS}" -o ${BUILD_DIR}/${BINARY_NAME}-${OS}-${ARCH}/${FILENAME} ${MAIN_FILE}
         done
     done
 }


### PR DESCRIPTION
## Summary

使 gocron 在 Termux (Android) 环境下端到端可用：从运行时的 DNS/TLS/bash 适配，到构建时 `android-arm64` 交叉编译。

## Changes

### Runtime — `internal/modules/utils/utils_unix.go`

| 功能 | 说明 |
|---|---|
| `isTermux()` | 检查 `/data/data/com.termux/files/usr/etc/termux` 统一判断环境 |
| `termuxPrefix()` | 派生所有 Termux 路径，避免硬编码分散 |
| `init()` — DNS | Termux 无 `/etc/resolv.conf`，用 `net.DefaultResolver` 接管；优先读用户 `resolv.conf`，回退 `114.114.114.114` |
| `init()` — TLS | 设置 `SSL_CERT_FILE` 指向 Termux CA 证书，解决 `x509: certificate signed by unknown authority` |
| `detectBashPath()` | 改用 `isTermux()` 判断，返回 `{prefix}/bin/bash` 或 `/bin/bash` |
| `ExecShell` | 临时目录改用 `os.TempDir()`，bash 路径动态检测 |

### Build — `package.sh` + `Makefile`

- `package.sh`：`SUPPORT_OS` 新增 `android`，编译时映射到 `GOOS=linux`，包名用 `android-arm64` 区别于标准 Linux
- `Makefile`：新增 `make package-termux`，`package-all` 同步加入 `android`

## Test plan

- [x] Linux 交叉编译通过 (`GOOS=linux GOARCH=arm64`)
- [x] `bash package.sh -p android -a arm64` 打包成功
- [x] 输出：`gocron-v1.6.6-android-arm64.tar.gz`
- [x] `detectBashPath` / `isTermux` / `readResolvConfDNS` / `setTermuxCACerts` 单元测试通过