### PR TITLE
fix(auth): apply user disable/demote/delete immediately to issued JWTs (GOC-11)

### DIFF
--- a/internal/routers/user/restore_token_test.go
+++ b/internal/routers/user/restore_token_test.go
@@ -1,0 +1,133 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gocronx-team/gocron/internal/models"
+	"github.com/gocronx-team/gocron/internal/modules/app"
+	"github.com/gocronx-team/gocron/internal/modules/setting"
+	"github.com/ncruces/go-sqlite3/gormlite"
+	"gorm.io/gorm"
+)
+
+// setupUserAuthDb 用内存 sqlite 替换全局 Db，并注入一个测试用的 AuthSecret。
+func setupUserAuthDb(t *testing.T) func() {
+	t.Helper()
+	db, err := gorm.Open(gormlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	origDb := models.Db
+	origSetting := app.Setting
+	models.Db = db
+	app.Setting = &setting.Setting{AuthSecret: "test-secret-abc"}
+	return func() {
+		models.Db = origDb
+		app.Setting = origSetting
+	}
+}
+
+func ctxWithToken(token string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/api/task", nil)
+	req.Header.Set("Auth-Token", token)
+	c.Request = req
+	return c
+}
+
+func createUser(t *testing.T, name, email string, isAdmin int8) *models.User {
+	t.Helper()
+	u := &models.User{Name: name, Email: email, Password: "secret123", IsAdmin: isAdmin}
+	if _, err := u.Create(); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return u
+}
+
+// 启用用户携带有效 token：应通过，并把 uid / is_admin 写入 context。
+func TestRestoreToken_EnabledUserPasses(t *testing.T) {
+	defer setupUserAuthDb(t)()
+	u := createUser(t, "alice", "alice@example.com", 1)
+	token, err := generateToken(u)
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+
+	c := ctxWithToken(token)
+	if _, err := RestoreToken(c); err != nil {
+		t.Fatalf("expected enabled user to pass, got: %v", err)
+	}
+	if Uid(c) != u.Id {
+		t.Fatalf("expected uid %d in context, got %d", u.Id, Uid(c))
+	}
+	if !IsAdmin(c) {
+		t.Fatalf("expected is_admin true in context")
+	}
+}
+
+// 禁用用户的既有 token：应被拒绝（即时吊销）。
+func TestRestoreToken_RejectsDisabledUser(t *testing.T) {
+	defer setupUserAuthDb(t)()
+	u := createUser(t, "bob", "bob@example.com", 0)
+	token, err := generateToken(u)
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+
+	if _, err := (&models.User{}).Disable(u.Id); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	c := ctxWithToken(token)
+	if _, err := RestoreToken(c); err == nil {
+		t.Fatal("expected disabled user's token to be rejected")
+	}
+}
+
+// 已删除用户的既有 token：应被拒绝。
+func TestRestoreToken_RejectsDeletedUser(t *testing.T) {
+	defer setupUserAuthDb(t)()
+	u := createUser(t, "carol", "carol@example.com", 0)
+	token, err := generateToken(u)
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+
+	if _, err := (&models.User{}).Delete(u.Id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	c := ctxWithToken(token)
+	if _, err := RestoreToken(c); err == nil {
+		t.Fatal("expected deleted user's token to be rejected")
+	}
+}
+
+// 降权：token 里固化 is_admin=1，但库中已改为 0，context 应取库中的最新值 0。
+func TestRestoreToken_UsesFreshRoleAfterDemotion(t *testing.T) {
+	defer setupUserAuthDb(t)()
+	u := createUser(t, "dave", "dave@example.com", 1)
+	token, err := generateToken(u) // 此时 token 的 is_admin=1
+	if err != nil {
+		t.Fatalf("generateToken: %v", err)
+	}
+
+	if _, err := (&models.User{}).Update(u.Id, models.CommonMap{"is_admin": 0}); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+
+	c := ctxWithToken(token)
+	if _, err := RestoreToken(c); err != nil {
+		t.Fatalf("expected demoted-but-enabled user to pass, got: %v", err)
+	}
+	if IsAdmin(c) {
+		t.Fatal("expected is_admin false after demotion (fresh value from DB)")
+	}
+}

--- a/internal/routers/user/user.go
+++ b/internal/routers/user/user.go
@@ -440,38 +440,35 @@ func RestoreToken(c *gin.Context) (string, error) {
 	if !ok {
 		return "", errors.New("invalid uid claim")
 	}
-	username, ok := claims["username"].(string)
-	if !ok {
-		return "", errors.New("invalid username claim")
-	}
-	isAdminF, ok := claims["is_admin"].(float64)
-	if !ok {
-		return "", errors.New("invalid is_admin claim")
-	}
 	expF, ok := claims["exp"].(float64)
 	if !ok {
 		return "", errors.New("invalid exp claim")
 	}
 
-	c.Set("uid", int(uidF))
-	c.Set("username", username)
-	c.Set("is_admin", int(isAdminF))
+	// 回查数据库中该用户的当前状态与角色，使禁用 / 降权 / 删除即时生效，
+	// 而不是信任 JWT 里固化的旧 claims（GOC-11）。
+	currentUser := &models.User{}
+	if err := currentUser.Find(int(uidF)); err != nil {
+		return "", errors.New("user not found")
+	}
+	if currentUser.Status != models.Enabled {
+		return "", errors.New("user disabled")
+	}
 
-	// 检查 token 是否即将过期（小于 1 小时）
+	c.Set("uid", currentUser.Id)
+	c.Set("username", currentUser.Name)
+	c.Set("is_admin", int(currentUser.IsAdmin))
+
+	// 检查 token 是否即将过期（小于 1 小时），用数据库里的最新角色重签，
+	// 避免自动续期把已被降权的旧权限无限延续下去。
 	exp := int64(expF)
 	if time.Until(time.Unix(exp, 0)) < time.Hour {
-		// 生成新 token
-		userModel := &models.User{
-			Id:      int(uidF),
-			Name:    username,
-			IsAdmin: int8(isAdminF),
-		}
-		newToken, err := generateToken(userModel)
+		newToken, err := generateToken(currentUser)
 		if err != nil {
 			logger.Warnf("刷新token失败: %v", err)
 			return "", nil
 		}
-		logger.Infof("用户 %s 的 token 已自动刷新", userModel.Name)
+		logger.Infof("用户 %s 的 token 已自动刷新", currentUser.Name)
 		return newToken, nil
 	}
 


### PR DESCRIPTION
## 问题 (Refs GOC-11)

`userAuth` → `RestoreToken` 只验证 JWT 签名并信任 token 里固化的 `uid` / `is_admin`，**从不回查数据库**：

- 禁用 / 降权 / 删除一个用户后，其现有 token 在有效期内（最长 4h）仍照常可用；
- token 距过期不足 1 小时时会用**旧 claims** 自动续签，持续使用的会话可被**无限续期**；
- 管理员被降权后 `is_admin` 仍固化在 token 中，`urlAuth` 读到的是陈旧值 → 降权滞后。

## 方案

`RestoreToken` 现在按 `uid` 回查当前用户：

- 用户不存在（已删除）或 `Status != Enabled`（已禁用）→ 拒绝请求（即时吊销）；
- `is_admin` 取数据库当前值写入 context → 降权即时生效；
- 自动续签改用数据库里的最新角色重签，而非旧 claim。

## 兼容性 / 影响

- 正常启用用户：行为不变（每次都能查到且 Status=Enabled）。
- 唯一行为变化：被禁用 / 降权 / 删除的用户立即失去访问 —— 即本 issue 要修的目标。
- 代价：每个已鉴权请求多一次用户主键查询（gocron 定位轻量、后台流量低，可接受；如需可后续加短 TTL 缓存）。

## 测试

新增 `internal/routers/user/restore_token_test.go`，覆盖启用通过 / 禁用拒绝 / 删除拒绝 / 降权后取库内最新角色四种场景。本地 `gofmt`、`go vet`、`go build ./...`（含前端 dist 桩）、`go test ./internal/routers/...` 均通过。
