### PR TITLE
perf(secret): cache decrypted secrets keyed by signature (GOC-16)

### DIFF
--- a/internal/models/secret.go
+++ b/internal/models/secret.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -82,6 +83,24 @@ func (s *Secret) All() ([]Secret, error) {
 	list := make([]Secret, 0)
 	err := Db.Order("name ASC").Find(&list).Error
 	return list, err
+}
+
+// CacheSignature 返回一个轻量签名,用于进程内解密缓存的失效判定:
+// 机密条数 + 最新更新时间。任何新增/删除(改变条数)或更新(改变
+// updated_at,GORM 在 Updates 时自动维护)都会改变该签名。返回的字符串
+// 只用于相等比较,其具体格式无关紧要(同一进程内驱动表示一致即可)。
+func (s *Secret) CacheSignature() (string, error) {
+	var row struct {
+		Cnt        int64
+		MaxUpdated string
+	}
+	err := Db.Model(&Secret{}).
+		Select("COUNT(*) AS cnt, COALESCE(MAX(updated_at), '') AS max_updated").
+		Scan(&row).Error
+	if err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(row.Cnt, 10) + "|" + row.MaxUpdated, nil
 }
 
 // Find 按 id 查找(含 Value)。

--- a/internal/service/secret_env_test.go
+++ b/internal/service/secret_env_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestLoadSecretEnvDecrypts(t *testing.T) {
+	resetSecretCache()
 	_ = os.Setenv(crypto.SecretKeyEnv, "svc-secret-test")
 	crypto.Init()
 	if !crypto.Configured() {
@@ -57,6 +58,7 @@ func TestSecretValuesEmpty(t *testing.T) {
 }
 
 func TestLoadSecretEnvSkipsReserved(t *testing.T) {
+	resetSecretCache()
 	_ = os.Setenv(crypto.SecretKeyEnv, "svc-reserved-test")
 	crypto.Init()
 	if !crypto.Configured() {
@@ -92,7 +94,82 @@ func TestLoadSecretEnvSkipsReserved(t *testing.T) {
 	}
 }
 
+func TestLoadSecretEnvCaching(t *testing.T) {
+	resetSecretCache()
+	_ = os.Setenv(crypto.SecretKeyEnv, "svc-cache-test")
+	crypto.Init()
+	if !crypto.Configured() {
+		t.Skip("crypto master key not configured")
+	}
+	db, err := gorm.Open(gormlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	original := models.Db
+	models.Db = db
+	defer func() { models.Db = original }()
+	if err := db.AutoMigrate(&models.Secret{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	enc := func(plain string) string {
+		ct, err := crypto.Encrypt(plain)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		return ct
+	}
+
+	if _, err := (&models.Secret{Name: "FOO", Value: enc("v1")}).Create(); err != nil {
+		t.Fatalf("create FOO: %v", err)
+	}
+	if got := loadSecretEnv(models.Task{})["FOO"]; got != "v1" {
+		t.Fatalf("expected FOO=v1, got %q", got)
+	}
+
+	// UpdateColumn 不触发 updated_at、条数不变 => 签名不变 => 应命中缓存,仍返回旧值 v1
+	if err := models.Db.Model(&models.Secret{}).Where("name = ?", "FOO").
+		UpdateColumn("value", enc("v2")).Error; err != nil {
+		t.Fatalf("sneaky update: %v", err)
+	}
+	if got := loadSecretEnv(models.Task{})["FOO"]; got != "v1" {
+		t.Fatalf("expected cached v1 while signature unchanged, got %q", got)
+	}
+
+	// 新增一条机密 => 条数变化 => 签名变化 => 缓存失效并重新解密:
+	// 此时 FOO 应读到最新的 v2,新机密 BAR 也应出现。
+	if _, err := (&models.Secret{Name: "BAR", Value: enc("b1")}).Create(); err != nil {
+		t.Fatalf("create BAR: %v", err)
+	}
+	env := loadSecretEnv(models.Task{})
+	if env["FOO"] != "v2" {
+		t.Errorf("after invalidation FOO should refresh to v2, got %q", env["FOO"])
+	}
+	if env["BAR"] != "b1" {
+		t.Errorf("new secret BAR should appear after invalidation, got %q", env["BAR"])
+	}
+
+	// 删除 BAR => 条数变化 => 缓存失效 => BAR 消失。
+	if _, err := (&models.Secret{}).Delete(env2Id(t)); err != nil {
+		t.Fatalf("delete BAR: %v", err)
+	}
+	if _, ok := loadSecretEnv(models.Task{})["BAR"]; ok {
+		t.Error("BAR should disappear after deletion invalidates the cache")
+	}
+}
+
+// env2Id 返回 BAR 的主键 id(测试辅助)。
+func env2Id(t *testing.T) int {
+	t.Helper()
+	s := &models.Secret{}
+	if err := models.Db.Where("name = ?", "BAR").First(s).Error; err != nil {
+		t.Fatalf("lookup BAR id: %v", err)
+	}
+	return s.Id
+}
+
 func TestLoadSecretEnvWhitelistScoping(t *testing.T) {
+	resetSecretCache()
 	_ = os.Setenv(crypto.SecretKeyEnv, "svc-whitelist-test")
 	crypto.Init()
 	if !crypto.Configured() {

--- a/internal/service/task.go
+++ b/internal/service/task.go
@@ -497,13 +497,84 @@ func (h *RPCHandler) Run(taskModel models.Task, taskUniqueId int64, secretEnv ma
 
 // loadSecretEnv 读取机密并解密为 name->明文 映射,用于注入任务执行环境。
 // 任务配置了机密白名单(SecretNames)时,仅解密注入白名单内的机密,实现任务级作用域隔离;
+// 解密后的全量机密进程内缓存(name -> 明文),按 CacheSignature 失效。
+// 高频任务(如每秒级)由此免去每次执行的全表查询 + 逐条 AES 解密。
+var (
+	secretCacheMu    sync.Mutex
+	secretCacheMap   map[string]string
+	secretCacheSig   string
+	secretCacheValid bool
+)
+
+// resetSecretCache 使缓存失效,仅供测试在切换 models.Db 后隔离状态使用。
+func resetSecretCache() {
+	secretCacheMu.Lock()
+	secretCacheValid = false
+	secretCacheMap = nil
+	secretCacheSig = ""
+	secretCacheMu.Unlock()
+}
+
+// decryptAllSecrets 全表拉取并逐条解密,构建 name -> 明文 映射(跳过受保护名与解密失败项)。
+func decryptAllSecrets() (map[string]string, error) {
+	all, err := new(models.Secret).All()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, len(all))
+	failed := 0
+	for _, s := range all {
+		// 纵深防御:跳过受保护的系统环境变量名,防止绕过 API 写入的坏数据覆盖 PATH/LD_PRELOAD 等
+		if models.IsReservedEnvName(s.Name) {
+			logger.Warnf("跳过受保护的机密名#%s(不允许覆盖系统环境变量)", s.Name)
+			continue
+		}
+		plain, err := crypto.Decrypt(s.Value)
+		if err != nil {
+			failed++
+			continue
+		}
+		m[s.Name] = plain
+	}
+	// 汇总告警:解密失败通常意味着 GOCRON_SECRET_KEY 已变更,否则任务会静默拿不到机密
+	if failed > 0 {
+		logger.Errorf("有 %d 条机密解密失败,可能 GOCRON_SECRET_KEY 已变更;相关任务将无法获取这些机密,请检查主密钥或重建机密", failed)
+	}
+	return m, nil
+}
+
+// cachedSecrets 返回全量解密机密映射,命中缓存则免去重复解密;签名变化时重建。
+// 返回的 map 为共享只读副本,调用方不得修改。
+func cachedSecrets() (map[string]string, error) {
+	sig, err := new(models.Secret).CacheSignature()
+	if err != nil {
+		// 签名查询失败:降级为直接解密(保持行为正确,只是不走缓存)
+		logger.Warnf("获取机密缓存签名失败,降级为直接解密: %v", err)
+		return decryptAllSecrets()
+	}
+
+	secretCacheMu.Lock()
+	defer secretCacheMu.Unlock()
+	if secretCacheValid && secretCacheSig == sig {
+		return secretCacheMap, nil
+	}
+	m, err := decryptAllSecrets()
+	if err != nil {
+		return nil, err
+	}
+	secretCacheMap = m
+	secretCacheSig = sig
+	secretCacheValid = true
+	return m, nil
+}
+
 // 未配置白名单的任务保持历史行为,注入全部机密。
 // 未配置加密或读取/解密失败时安全降级(返回 nil 或跳过失败项)。
 func loadSecretEnv(taskModel models.Task) map[string]string {
 	if !crypto.Configured() {
 		return nil
 	}
-	all, err := new(models.Secret).All()
+	all, err := cachedSecrets()
 	if err != nil {
 		logger.Warnf("加载机密失败: %v", err)
 		return nil
@@ -520,33 +591,18 @@ func loadSecretEnv(taskModel models.Task) map[string]string {
 		}
 	}
 	env := make(map[string]string, len(all))
-	failed := 0
-	for _, s := range all {
+	for name, plain := range all {
 		if allowed != nil {
-			if !allowed[s.Name] {
+			if !allowed[name] {
 				continue
 			}
-			delete(allowed, s.Name)
+			delete(allowed, name)
 		}
-		// 纵深防御:跳过受保护的系统环境变量名,防止绕过 API 写入的坏数据覆盖 PATH/LD_PRELOAD 等
-		if models.IsReservedEnvName(s.Name) {
-			logger.Warnf("跳过受保护的机密名#%s(不允许覆盖系统环境变量)", s.Name)
-			continue
-		}
-		plain, err := crypto.Decrypt(s.Value)
-		if err != nil {
-			failed++
-			continue
-		}
-		env[s.Name] = plain
+		env[name] = plain
 	}
 	// 白名单中引用了不存在的机密名:任务将拿不到该变量,给出告警便于排查
 	for name := range allowed {
 		logger.Warnf("任务#%d(%s)机密白名单引用了不存在的机密#%s", taskModel.Id, taskModel.Name, name)
-	}
-	// 汇总告警:解密失败通常意味着 GOCRON_SECRET_KEY 已变更,否则任务会静默拿不到机密
-	if failed > 0 {
-		logger.Errorf("有 %d 条机密解密失败,可能 GOCRON_SECRET_KEY 已变更;相关任务将无法获取这些机密,请检查主密钥或重建机密", failed)
 	}
 	return env
 }


### PR DESCRIPTION
## Problem (Refs GOC-16)

`loadSecretEnv` ran a **full `secret` table query + a per-row AES decrypt on every task execution**. For high-frequency tasks (e.g. per-second) this is a real DB + CPU cost, and it scales with the number of secrets.

## Change

Cache the decrypted `name -> plaintext` map process-wide, keyed by a **cheap signature**: `COUNT(*)` + `MAX(updated_at)` (new `models.Secret.CacheSignature()`).

- On a cache hit (signature unchanged) the expensive full-fetch + AES decrypt is skipped entirely.
- Any create / update / delete changes the row count or `updated_at`, so the signature changes and the cache rebuilds — results stay **fresh with no staleness and no cross-node coordination** (each node validates against its own DB view).
- Per-task whitelist scoping, reserved-name skipping, and decrypt-failure warnings are preserved.
- If the (cheap) signature query fails, it falls back to a direct decrypt — behaviour stays correct, just uncached.

## Compatibility

Behaviour is unchanged for callers; only the redundant work is removed. No schema change (reuses existing `updated_at`).

## Tests

New `TestLoadSecretEnvCaching` proves a cache hit serves the cached value while the signature is unchanged, and that add / update / delete invalidate it and refresh the decrypted values. Existing secret-env tests reset the cache for isolation. Local `gofmt`/`go vet`/`go build ./...`/`go test ./internal/service/... ./internal/models/...` all pass.
