### PR TITLE
fix(task): stop shifting the status filter value (#236)

### DIFF
--- a/internal/routers/base/base.go
+++ b/internal/routers/base/base.go
@@ -2,10 +2,27 @@ package base
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gocronx-team/gocron/internal/models"
 )
+
+// ParseStatusFilter 解析可选的状态过滤查询值。
+// 空字符串、非数字或负数一律返回 -1,表示"不按状态过滤";否则返回原始状态
+// 枚举值(与数据库存储值一致)。调用方不得再做 ±1 调整——前端直接传枚举值
+// (如任务:启用=1/禁用=0;日志:失败=0/运行中=1/成功=2/取消=3)。
+func ParseStatusFilter(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return -1
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return -1
+	}
+	return v
+}
 
 // ParsePageAndPageSize 解析查询参数中的页数和每页数量
 func ParsePageAndPageSize(c *gin.Context, params models.CommonMap) {

--- a/internal/routers/base/base_test.go
+++ b/internal/routers/base/base_test.go
@@ -1,0 +1,30 @@
+package base
+
+import "testing"
+
+// TestParseStatusFilter 锁定状态过滤解析:空/非法 -> -1(不过滤),否则原样返回枚举值。
+// 这是 issue #236 的回归测试:此前 handler 对状态值多减了 1,导致
+// 任务列表(启用=1/禁用=0)与任务日志(失败=0/运行中=1/成功=2/取消=3)
+// 的过滤结果与所选状态错位。
+func TestParseStatusFilter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", -1},    // 未选择 -> 不过滤
+		{"   ", -1}, // 纯空白 -> 不过滤
+		{"abc", -1}, // 非数字 -> 不过滤
+		{"-1", -1},  // 负数 -> 不过滤
+		{"-5", -1},  // 负数 -> 不过滤
+		{"0", 0},    // 禁用 / 失败
+		{"1", 1},    // 启用 / 运行中
+		{"2", 2},    // 成功
+		{"3", 3},    // 取消
+		{" 2 ", 2},  // 容忍首尾空白
+	}
+	for _, tc := range cases {
+		if got := ParseStatusFilter(tc.in); got != tc.want {
+			t.Errorf("ParseStatusFilter(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/routers/task/task.go
+++ b/internal/routers/task/task.go
@@ -513,16 +513,13 @@ func parseQueryParams(c *gin.Context) models.CommonMap {
 	id, _ := strconv.Atoi(c.Query("id"))
 	hostId, _ := strconv.Atoi(c.Query("host_id"))
 	protocol, _ := strconv.Atoi(c.Query("protocol"))
-	status, _ := strconv.Atoi(c.Query("status"))
 	params["Id"] = id
 	params["HostId"] = hostId
 	params["Name"] = strings.TrimSpace(c.Query("name"))
 	params["Protocol"] = protocol
 	params["Tag"] = strings.TrimSpace(c.Query("tag"))
-	if status >= 0 {
-		status -= 1
-	}
-	params["Status"] = status
+	// 前端直接传状态枚举值(启用=1/禁用=0),空值表示不过滤。
+	params["Status"] = base.ParseStatusFilter(c.Query("status"))
 	base.ParsePageAndPageSize(c, params)
 
 	return params

--- a/internal/routers/tasklog/task_log.go
+++ b/internal/routers/tasklog/task_log.go
@@ -116,14 +116,11 @@ func parseQueryParams(c *gin.Context) models.CommonMap {
 	var params models.CommonMap = models.CommonMap{}
 	taskId, _ := strconv.Atoi(c.Query("task_id"))
 	protocol, _ := strconv.Atoi(c.Query("protocol"))
-	status, _ := strconv.Atoi(c.Query("status"))
 	params["TaskId"] = taskId
 	params["Protocol"] = protocol
 	params["Keyword"] = strings.TrimSpace(c.Query("keyword"))
-	if status >= 0 {
-		status -= 1
-	}
-	params["Status"] = status
+	// 前端直接传状态枚举值(失败=0/运行中=1/成功=2/取消=3),空值表示不过滤。
+	params["Status"] = base.ParseStatusFilter(c.Query("status"))
 	base.ParsePageAndPageSize(c, params)
 
 	return params


### PR DESCRIPTION
Fixes #236

## Problem

On the **Task list** and **Task log** pages, filtering by status returned rows for the wrong status:
- Task list: choosing *Enabled* showed *disabled* tasks, and vice-versa.
- Task log: choosing *Failed* showed *Success*, *Running* showed *Failed*, etc.

## Root cause

Both `parseQueryParams` handlers subtracted 1 from the incoming `status` value:

```go
status, _ := strconv.Atoi(c.Query("status"))
if status >= 0 { status -= 1 }
params["Status"] = status
```

This was a stale hack from when the UI sent **1-based** status values (0 = "no filter"). The current UI sends the **raw enum value** (task: enabled=1 / disabled=0; log: failed=0 / running=1 / success=2 / cancelled=3) with an **empty** value for "no filter". So:
- select *Enabled* (1) → `1-1=0` → queried `status = 0` (disabled) → showed disabled tasks;
- select *Disabled* (0) → `-1` → filter skipped → showed everything;
- log *Running* (1) → `0` → queried failed; etc.

## Fix

Add `base.ParseStatusFilter(raw string) int`:
- empty / non-numeric / negative → `-1` (no filter, matches the existing `status > -1` guard in both `parseWhere`);
- otherwise the raw enum value, unchanged.

Use it in both `internal/routers/task` and `internal/routers/tasklog`, removing the `-1` shift. The DB layer already filters correctly with the raw value; no query/schema change needed.

## Tests

Adds `TestParseStatusFilter` covering empty/whitespace/invalid/negative → -1 and 0/1/2/3 pass-through. Existing task/tasklog handler tests still pass.

## Verification

`gofmt` / `go vet` / `go build ./...` / `go test -race ./internal/routers/...` all pass locally. The DB-side filter (`WHERE status = ?`) is unchanged and driver-agnostic, so the fix applies to PostgreSQL (the reporter's DB) as well as MySQL/SQLite.
