### PR TITLE
chore(release): consolidate release as v1.9.0

### DIFF
--- a/cmd/gocron/gocron.go
+++ b/cmd/gocron/gocron.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	AppVersion           = "1.10.0"
+	AppVersion           = "1.9.0"
 	BuildDate, GitCommit string
 
 	// leaderElection 全局选举实例，用于 graceful shutdown 时释放锁

--- a/internal/models/migration.go
+++ b/internal/models/migration.go
@@ -46,7 +46,7 @@ func (migration *Migration) Upgrade(oldVersionId int) {
 		return
 	}
 
-	versionIds := []int{110, 122, 130, 140, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 1510, 160, 163, 170, 180, 190, 1100}
+	versionIds := []int{110, 122, 130, 140, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 1510, 160, 163, 170, 180, 190}
 	upgradeFuncs := []func(*gorm.DB) error{
 		migration.upgradeFor110,
 		migration.upgradeFor122,
@@ -68,7 +68,6 @@ func (migration *Migration) Upgrade(oldVersionId int) {
 		migration.upgradeFor170,
 		migration.upgradeFor180,
 		migration.upgradeFor190,
-		migration.upgradeFor1100,
 	}
 
 	startIndex := upgradeStartIndex(oldVersionId, versionIds)
@@ -821,19 +820,12 @@ func (m *Migration) upgradeFor180(tx *gorm.DB) error {
 func (m *Migration) upgradeFor190(tx *gorm.DB) error {
 	logger.Info("开始升级到v1.9.0")
 
+	// 任务级机密白名单:新增 secret_names 列(空串=注入全部,兼容旧行为)。
 	if !tx.Migrator().HasColumn(&Task{}, "secret_names") {
 		if err := tx.Migrator().AddColumn(&Task{}, "SecretNames"); err != nil {
 			return err
 		}
 	}
-
-	logger.Info("已升级到v1.9.0")
-
-	return nil
-}
-
-func (m *Migration) upgradeFor1100(tx *gorm.DB) error {
-	logger.Info("开始升级到v1.10.0")
 
 	// 通知增强:新增 notify_keyword_exclude 列(排除关键字,命中则不通知)。
 	// 存量数据默认空串 = 不排除,旧任务行为不变。
@@ -849,7 +841,7 @@ func (m *Migration) upgradeFor1100(tx *gorm.DB) error {
 		}
 	}
 
-	logger.Info("已升级到v1.10.0")
+	logger.Info("已升级到v1.9.0")
 
 	return nil
 }

--- a/internal/models/migration_190_test.go
+++ b/internal/models/migration_190_test.go
@@ -7,7 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestUpgradeFor190AddsSecretNamesColumn(t *testing.T) {
+func TestUpgradeFor190AddsColumns(t *testing.T) {
 	db, err := gorm.Open(gormlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
@@ -16,12 +16,19 @@ func TestUpgradeFor190AddsSecretNamesColumn(t *testing.T) {
 	Db = db
 	defer func() { Db = original }()
 
-	if err := db.AutoMigrate(&Task{}); err != nil {
+	if err := db.AutoMigrate(&Task{}, &TaskTemplate{}); err != nil {
 		t.Fatalf("pre-migrate tables: %v", err)
 	}
-	// 模拟升级前的旧库:去掉列,让 upgradeFor190 真正走 AddColumn 分支
+	// 模拟升级前的旧库:去掉这几列,让 upgradeFor190 真正走 AddColumn 分支。
+	// v1.9.0 一次性引入 secret_names(机密白名单)与 notify_keyword_exclude(通知排除关键字)。
 	if err := db.Migrator().DropColumn(&Task{}, "secret_names"); err != nil {
-		t.Fatalf("drop task column: %v", err)
+		t.Fatalf("drop task.secret_names: %v", err)
+	}
+	if err := db.Migrator().DropColumn(&Task{}, "notify_keyword_exclude"); err != nil {
+		t.Fatalf("drop task.notify_keyword_exclude: %v", err)
+	}
+	if err := db.Migrator().DropColumn(&TaskTemplate{}, "notify_keyword_exclude"); err != nil {
+		t.Fatalf("drop task_template.notify_keyword_exclude: %v", err)
 	}
 
 	m := &Migration{}
@@ -31,13 +38,20 @@ func TestUpgradeFor190AddsSecretNamesColumn(t *testing.T) {
 	if !db.Migrator().HasColumn(&Task{}, "secret_names") {
 		t.Error("task.secret_names not added by upgradeFor190")
 	}
+	if !db.Migrator().HasColumn(&Task{}, "notify_keyword_exclude") {
+		t.Error("task.notify_keyword_exclude not added by upgradeFor190")
+	}
+	if !db.Migrator().HasColumn(&TaskTemplate{}, "notify_keyword_exclude") {
+		t.Error("task_template.notify_keyword_exclude not added by upgradeFor190")
+	}
 
 	// 幂等:列已存在时再次执行不应报错
 	if err := m.upgradeFor190(db); err != nil {
 		t.Fatalf("upgradeFor190 not idempotent: %v", err)
 	}
 
-	// 升级后的存量任务 secret_names 为空串 → 白名单解析为 nil(注入全部,兼容旧行为)
+	// 升级后的存量任务:secret_names 为空串 → 白名单解析为 nil(注入全部);
+	// notify_keyword_exclude 为空串 → 不排除。均兼容旧行为。
 	task := &Task{Name: "legacy", Protocol: TaskRPC, Command: "echo ok", Spec: "@daily"}
 	if _, err := task.Create(); err != nil {
 		t.Fatalf("create task: %v", err)
@@ -51,6 +65,9 @@ func TestUpgradeFor190AddsSecretNamesColumn(t *testing.T) {
 	}
 	if loaded.SecretNameList() != nil {
 		t.Errorf("empty secret_names must parse to nil whitelist, got %v", loaded.SecretNameList())
+	}
+	if loaded.NotifyKeywordExclude != "" {
+		t.Errorf("expected empty notify_keyword_exclude for legacy task, got %q", loaded.NotifyKeywordExclude)
 	}
 }
 

--- a/internal/models/migration_upgrade_test.go
+++ b/internal/models/migration_upgrade_test.go
@@ -23,47 +23,6 @@ func newMigrationTestDb(t *testing.T) *gorm.DB {
 	return db
 }
 
-func TestUpgradeFor1100AddsNotifyKeywordExcludeColumn(t *testing.T) {
-	db := newMigrationTestDb(t)
-
-	// 模拟升级前的旧库:去掉列,让 upgradeFor1100 真正走 AddColumn 分支
-	if err := db.Migrator().DropColumn(&Task{}, "notify_keyword_exclude"); err != nil {
-		t.Fatalf("drop task column: %v", err)
-	}
-	if err := db.Migrator().DropColumn(&TaskTemplate{}, "notify_keyword_exclude"); err != nil {
-		t.Fatalf("drop template column: %v", err)
-	}
-
-	m := &Migration{}
-	if err := m.upgradeFor1100(db); err != nil {
-		t.Fatalf("upgradeFor1100 error: %v", err)
-	}
-	if !db.Migrator().HasColumn(&Task{}, "notify_keyword_exclude") {
-		t.Error("task.notify_keyword_exclude not added by upgradeFor1100")
-	}
-	if !db.Migrator().HasColumn(&TaskTemplate{}, "notify_keyword_exclude") {
-		t.Error("task_template.notify_keyword_exclude not added by upgradeFor1100")
-	}
-
-	// 幂等:列已存在时再次执行不应报错
-	if err := m.upgradeFor1100(db); err != nil {
-		t.Fatalf("upgradeFor1100 not idempotent: %v", err)
-	}
-
-	// 存量任务排除关键字为空串 → 不排除,旧行为不变
-	task := &Task{Name: "legacy", Protocol: TaskRPC, Command: "echo ok", Spec: "@daily"}
-	if _, err := task.Create(); err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	var loaded Task
-	if err := db.First(&loaded, task.Id).Error; err != nil {
-		t.Fatalf("load task: %v", err)
-	}
-	if loaded.NotifyKeywordExclude != "" {
-		t.Errorf("expected empty notify_keyword_exclude for legacy task, got %q", loaded.NotifyKeywordExclude)
-	}
-}
-
 // upgradeFor170 的 notify_status 单选值→位掩码重映射不可重入;它必须只在
 // notify_keyword_regex 列首次创建时执行,列已存在时重复调用不得再改写数据。
 func TestUpgradeFor170RemapNotRerunWhenColumnExists(t *testing.T) {
@@ -138,7 +97,7 @@ func TestUpgradeFor170RemapRunsOnLegacyDb(t *testing.T) {
 }
 
 func TestUpgradeStartIndex(t *testing.T) {
-	versionIds := []int{110, 122, 130, 140, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 1510, 160, 163, 170, 180, 190, 1100}
+	versionIds := []int{110, 122, 130, 140, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 1510, 160, 163, 170, 180, 190}
 
 	tests := []struct {
 		name string
@@ -146,14 +105,13 @@ func TestUpgradeStartIndex(t *testing.T) {
 		want int
 	}{
 		// 精确匹配:从旧版本号的下一项开始
-		{"from 190 runs only 1100", 190, 20},
-		{"from 180", 180, 19},
+		{"from 180 runs only 190", 180, 19},
 		{"from 170", 170, 18},
 		// 1510(v1.5.10)数值大于其后的 160~190,精确匹配保证不会从它重复迁移
 		{"from 1510 continues at 160", 1510, 15},
 		{"from 159 continues at 1510", 159, 14},
-		// 已是最新版本:无需升级
-		{"latest version nothing to run", 1100, -1},
+		// 已是最新版本(190 = v1.9.0):无需升级
+		{"latest version nothing to run", 190, -1},
 		// 未收录的版本号(发过无迁移的补丁版)退回「第一个大于旧版本」扫描
 		{"unlisted 161 falls back before 1510 era ends", 161, 14},
 		{"unlisted 111 falls back to 122", 111, 1},


### PR DESCRIPTION
Consolidates the pending release under a single tag: **v1.9.0**.

## Why

`AppVersion` had been bumped `1.8.0 → 1.9.0 → 1.10.0` in code, but **neither 1.9.0 nor 1.10.0 was ever tagged/released**. Two separate migrations existed (`upgradeFor190` = secret whitelist `secret_names`; `upgradeFor1100` = notify exclude `notify_keyword_exclude`). Releasing as a single **v1.9.0** keeps the tag, the compiled `AppVersion`, and the migration version id (`190`) consistent.

## Changes

- `AppVersion`: `1.10.0 → 1.9.0`.
- Fold the `notify_keyword_exclude` column adds (Task + TaskTemplate) into `upgradeFor190`; remove `upgradeFor1100`; drop `1100` from the migration chain (`versionIds` / `upgradeFuncs`).
- Tests: extend the 190 migration test to assert both `secret_names` and `notify_keyword_exclude`; remove the 1100 test; fix `TestUpgradeStartIndex` expectations (190 is now the latest). Rename `migration_1100_test.go` → `migration_upgrade_test.go`.

## Safety

Both migrations are **additive column adds** with empty-string defaults — no data rewrite. Neither version was released, so folding is safe. Fresh installs get the columns via `AutoMigrate`; upgrades from ≤1.8.0 run `upgradeFor190` which now adds all three columns idempotently.

## Verification (local, full gate)

`gofmt` ✓, `go vet` ✓, `golangci-lint` v2.12.2 → **0 issues** ✓, `go test -race ./...` ✓, frontend `build-only` + `vue-tsc --noEmit` + `lint` ✓.
