### PR TITLE
chore(release): bump version to v1.9.1

### DIFF
--- a/cmd/gocron/gocron.go
+++ b/cmd/gocron/gocron.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	AppVersion           = "1.9.0"
+	AppVersion           = "1.9.1"
 	BuildDate, GitCommit string
 
 	// leaderElection 全局选举实例，用于 graceful shutdown 时释放锁


### PR DESCRIPTION
Bump `AppVersion` in `cmd/gocron/gocron.go` from 1.9.0 to 1.9.1 for the v1.9.1 release.

Patch release containing dependency updates merged since v1.9.0 (#241 #242 #243 #244). No schema changes, no new DB migration needed.

After merge, tag `v1.9.1` on the merge commit to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)