### PR TITLE
chore(release): bump version to 1.10.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   frontend:
@@ -72,3 +73,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prevtag.outputs.tag }}
+
+  container:
+    name: Publish Container Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Record build time
+        id: build
+        run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.gocron
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Make container package public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh api --method PATCH
+          "/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}"
+          -f visibility=public

--- a/Dockerfile.gocron
+++ b/Dockerfile.gocron
@@ -23,6 +23,9 @@ FROM golang:1.26-alpine AS builder
 RUN apk add --no-cache git
 
 WORKDIR /app
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
 COPY go.mod go.sum ./
 # Cache the Go module cache across builds
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -38,7 +41,9 @@ COPY . .
 # Cache module + build caches so incremental rebuilds are fast.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o gocron ./cmd/gocron
+    CGO_ENABLED=0 go build \
+      -ldflags="-s -w -X 'main.AppVersion=${VERSION}' -X 'main.GitCommit=${GIT_COMMIT}' -X 'main.BuildDate=${BUILD_DATE}'" \
+      -trimpath -o gocron ./cmd/gocron
 
 FROM alpine:latest
 

--- a/cmd/gocron/gocron.go
+++ b/cmd/gocron/gocron.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	AppVersion           = "1.10.0"
+	AppVersion           = "1.10.1"
 	BuildDate, GitCommit string
 
 	// leaderElection 全局选举实例，用于 graceful shutdown 时释放锁

--- a/docs/en/guide/kubernetes.md
+++ b/docs/en/guide/kubernetes.md
@@ -42,7 +42,7 @@ helm install gocron gocron/gocron -f my-values.yaml
 ### Upgrade
 
 ```bash
-helm upgrade gocron gocron/gocron --set image.tag=1.5.9
+helm upgrade gocron gocron/gocron --set image.tag=1.10.1
 ```
 
 ### Uninstall
@@ -57,7 +57,7 @@ helm uninstall gocron
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Image repository | `gocronx/gocron` |
+| `image.repository` | Image repository | `ghcr.io/gocronx-team/gocron` |
 | `image.tag` | Image tag | Chart appVersion |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 

--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -145,10 +145,10 @@ docker compose up -d
 
 Deploy to Kubernetes clusters with a single command using Helm Chart.
 
-::: warning Image version note
-The Helm Chart defaults to the Docker Hub image `gocronx/gocron`, with the tag defaulting to the Chart's appVersion.
-Image publishing may currently lag behind GitHub Releases, so verify the target tag exists before installing —
-set it explicitly with `--set image.tag=<existing-tag>` if needed, or build and push your own image.
+::: tip Container image
+The Helm Chart defaults to the public image `ghcr.io/gocronx-team/gocron`, with
+the tag defaulting to the Chart's appVersion. Release tags publish matching
+multi-architecture images for Linux AMD64 and ARM64.
 :::
 
 ### Add Helm Repository

--- a/docs/zh/guide/kubernetes.md
+++ b/docs/zh/guide/kubernetes.md
@@ -42,7 +42,7 @@ helm install gocron gocron/gocron -f my-values.yaml
 ### 升级
 
 ```bash
-helm upgrade gocron gocron/gocron --set image.tag=1.5.9
+helm upgrade gocron gocron/gocron --set image.tag=1.10.1
 ```
 
 ### 卸载
@@ -57,7 +57,7 @@ helm uninstall gocron
 
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
-| `image.repository` | 镜像地址 | `gocronx/gocron` |
+| `image.repository` | 镜像地址 | `ghcr.io/gocronx-team/gocron` |
 | `image.tag` | 镜像标签 | Chart appVersion |
 | `image.pullPolicy` | 拉取策略 | `IfNotPresent` |
 

--- a/docs/zh/guide/quick-start.md
+++ b/docs/zh/guide/quick-start.md
@@ -145,10 +145,9 @@ docker compose up -d
 
 使用 Helm Chart 一键部署到 Kubernetes 集群。
 
-::: warning 镜像版本提示
-Helm Chart 默认使用 Docker Hub 镜像 `gocronx/gocron`，tag 默认取 Chart 的 appVersion。
-该镜像的发布目前可能滞后于 GitHub Releases，安装前请先确认目标 tag 是否存在，
-必要时通过 `--set image.tag=<已存在的 tag>` 显式指定，或自行构建并推送镜像。
+::: tip 容器镜像
+Helm Chart 默认使用公开镜像 `ghcr.io/gocronx-team/gocron`，tag 默认取 Chart 的
+appVersion。发布版本标签时会同步生成 Linux AMD64 和 ARM64 多架构镜像。
 :::
 
 ### 添加 Helm 仓库

--- a/helm/gocron/Chart.yaml
+++ b/helm/gocron/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gocron
 description: A Helm chart for gocron - cron job management system
 type: application
-version: 0.1.2
-appVersion: "1.10.0"
+version: 0.1.3
+appVersion: "1.10.1"
 keywords:
   - cron
   - scheduler

--- a/helm/gocron/values.yaml
+++ b/helm/gocron/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: gocronx/gocron
+  repository: ghcr.io/gocronx-team/gocron
   tag: "" # defaults to Chart appVersion
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump the application and Helm chart versions
- publish multi-architecture container images to GHCR
- update English and Chinese Helm deployment documentation

## Verification
- gofmt -l .
- go vet ./...
- golangci-lint run ./...
- go test -race -coverprofile=coverage.out ./...
- pnpm --dir web/gocronx-admin build-only
- pnpm --dir web/gocronx-admin exec vue-tsc --noEmit
- pnpm --dir web/gocronx-admin lint
- pnpm --dir docs docs:build
- helm lint helm/gocron
- helm template gocron helm/gocron --namespace gocron
- docker build and container version check