### PR TITLE
fix(ci): remove unsupported package visibility update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,11 +122,3 @@ jobs:
             BUILD_DATE=${{ steps.build.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Make container package public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          gh api --method PATCH
-          "/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}"
-          -f visibility=public


### PR DESCRIPTION
Remove the unsupported GitHub Packages visibility API call that causes otherwise successful container releases to fail. Package visibility is configured once in GHCR package settings.