### PR TITLE
fix(helm): persist writable application config

### DIFF
--- a/docs/en/guide/kubernetes.md
+++ b/docs/en/guide/kubernetes.md
@@ -211,6 +211,11 @@ persistence:
 ## Notes
 
 1. **SQLite mode**: Deployment strategy is automatically set to `Recreate` (instead of `RollingUpdate`) to prevent multiple Pods from accessing the SQLite file simultaneously
-2. **Config changes**: Pods automatically restart when ConfigMap changes (via checksum annotation)
-3. **Data persistence**: Always enable PVC in SQLite mode, otherwise data is lost when Pods restart
+2. **Configuration persistence**: The ConfigMap seeds `app.ini` only when the
+   file is missing or empty. The writable file, installation lock, and generated
+   authentication secret then live on the data volume so the web installer can
+   finish and Pod restarts preserve the installation.
+3. **Data persistence**: Keep PVC enabled when using the web installer or SQLite;
+   otherwise configuration, the installation lock, and SQLite data are lost when
+   the Pod is recreated.
 4. **Health checks**: Liveness and readiness probes are configured by default, checking HTTP on port 5920

--- a/docs/zh/guide/kubernetes.md
+++ b/docs/zh/guide/kubernetes.md
@@ -209,6 +209,9 @@ persistence:
 ## 注意事项
 
 1. **SQLite 模式**：Deployment 策略自动设为 `Recreate`（而非 `RollingUpdate`），避免多 Pod 同时访问 SQLite 文件
-2. **配置变更**：修改 ConfigMap 后 Pod 会自动重启（通过 checksum annotation 实现）
-3. **数据持久化**：SQLite 模式下务必启用 PVC，否则 Pod 重启后数据丢失
+2. **配置持久化**：仅当 `app.ini` 不存在或为空时，ConfigMap 才会提供初始配置；之后
+   可写配置文件、安装锁和自动生成的认证密钥均保存在数据卷中，因此 Web 安装向导可以
+   正常完成，Pod 重启后也会保留安装状态。
+3. **数据持久化**：使用 Web 安装向导或 SQLite 时应保持 PVC 启用，否则 Pod 重建后会
+   丢失配置、安装锁和 SQLite 数据。
 4. **健康检查**：默认配置了 liveness 和 readiness 探针，通过 HTTP 检查 5920 端口

--- a/helm/gocron/Chart.yaml
+++ b/helm/gocron/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gocron
 description: A Helm chart for gocron - cron job management system
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.10.1"
 keywords:
   - cron

--- a/helm/gocron/templates/deployment.yaml
+++ b/helm/gocron/templates/deployment.yaml
@@ -25,6 +25,24 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "gocron.serviceAccountName" . }}
+      initContainers:
+        - name: initialize-config
+          image: "{{ .Values.image.repository }}:{{ include "gocron.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              mkdir -p /data/conf
+              if [ ! -s /data/conf/app.ini ]; then
+                cp /config-seed/app.ini /data/conf/app.ini
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config-seed
+              readOnly: true
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ include "gocron.imageTag" . }}"
@@ -51,9 +69,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /.gocron
-            - name: config
-              mountPath: /.gocron/conf/app.ini
-              subPath: app.ini
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Summary
- seed app.ini into the writable data volume before startup
- preserve installer configuration, authentication secret, and install lock across restarts
- publish Helm chart 0.1.4 and document persistence behavior

## Verification
- helm lint and template
- server-side Helm dry-run
- local upgrade and writable app.ini check
- gofmt, vet, golangci-lint, race tests
- frontend build, typecheck, lint
- VitePress docs build