### PR TITLE
fix(helm): support deterministic dashboard installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
           helm lint helm/gocron
           --set db.host=postgresql.default.svc
           --set db.password=ci-password
+          --set managed.authSecret=ci-auth-secret-with-at-least-32-characters
+          --set managed.encryptionKey=ci-encryption-key-with-at-least-32-characters
+          --set managed.admin.password=ci-admin-password
 
       - name: Verify application version alignment
         run: |

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,39 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'helm/**'
+      - '.github/workflows/helm-release.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@v5
+
+      - name: Verify application image exists
+        run: |
+          app_version=$(helm show chart helm/gocron | awk '/^appVersion:/ {gsub(/"/, "", $2); print $2}')
+          docker manifest inspect "ghcr.io/${GITHUB_REPOSITORY}:${app_version}" >/dev/null
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: helm
+          skip_existing: true
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/docs/en/guide/high-availability.md
+++ b/docs/en/guide/high-availability.md
@@ -37,6 +37,7 @@ scp -r .gocron/conf/ user@node2:/path/to/gocron/.gocron/conf/
 ```
 
 The directory contains:
+
 - `app.ini` — database and application settings
 - `install.lock` — marks the installation as complete
 - `.version` — current application version
@@ -96,7 +97,10 @@ helm install gocron gocron/gocron \
   --set db.port=5432 \
   --set db.user=gocron \
   --set db.password=replace-me \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 ```
 
 See [Kubernetes Deployment](./kubernetes) for existing Secret, scaling, HPA,

--- a/docs/en/guide/kubernetes.md
+++ b/docs/en/guide/kubernetes.md
@@ -33,6 +33,14 @@ db:
   user: gocron
   password: replace-me
   database: gocron
+
+managed:
+  authSecret: replace-with-at-least-32-random-characters
+  encryptionKey: replace-with-another-32-random-characters
+  admin:
+    username: admin
+    password: replace-with-a-strong-admin-password
+    email: admin@example.com
 ```
 
 ```bash
@@ -43,9 +51,11 @@ The database must already exist. On first startup, the replicas coordinate
 through a database advisory lock. One Pod creates the schema and administrator;
 the others wait, then all start with the same configuration.
 
-The Kubernetes deployment does not show the web installation wizard. The
-administrator defaults to `admin`; its generated password is stored in the
-release Secret:
+The Kubernetes deployment does not show the web installation wizard. When the
+Chart manages the runtime Secret, all four sensitive values shown above are
+required so rendering remains deterministic and compatible with preview-based
+dashboards such as KubeVision. The configured administrator password is stored
+in the release Secret:
 
 ```bash
 kubectl get secret gocron -o jsonpath='{.data.admin-password}' | base64 -d; echo
@@ -114,23 +124,25 @@ anti-affinity by default.
 
 ## Configuration
 
-| Parameter | Description | Default |
-|---|---|---|
-| `replicaCount` | Initial number of Pods | `2` |
-| `db.engine` | `mysql` or `postgres` | `postgres` |
-| `db.host` | Stable database endpoint | required |
-| `db.port` | Database port | `5432` |
-| `db.user` | Database user | `gocron` |
-| `db.password` | Database password for a Chart-managed Secret | required on first install |
-| `db.database` | Existing database name | `gocron` |
-| `managed.existingSecret` | Existing runtime Secret | `""` |
-| `managed.admin.username` | Bootstrap administrator | `admin` |
-| `managed.admin.password` | Bootstrap password; generated when empty | `""` |
-| `managed.admin.email` | Bootstrap administrator email | `admin@example.com` |
-| `autoscaling.enabled` | Create an HPA | `false` |
-| `podDisruptionBudget.enabled` | Protect availability during eviction | `true` |
-| `service.type` | Kubernetes Service type | `ClusterIP` |
-| `ingress.enabled` | Create an Ingress | `false` |
+| Parameter                     | Description                                   | Default                           |
+| ----------------------------- | --------------------------------------------- | --------------------------------- |
+| `replicaCount`                | Initial number of Pods                        | `2`                               |
+| `db.engine`                   | `mysql` or `postgres`                         | `postgres`                        |
+| `db.host`                     | Stable database endpoint                      | required                          |
+| `db.port`                     | Database port                                 | `5432`                            |
+| `db.user`                     | Database user                                 | `gocron`                          |
+| `db.password`                 | Database password for a Chart-managed Secret  | required                          |
+| `db.database`                 | Existing database name                        | `gocron`                          |
+| `managed.existingSecret`      | Existing runtime Secret                       | `""`                              |
+| `managed.authSecret`          | Shared JWT secret, at least 32 characters     | required without `existingSecret` |
+| `managed.encryptionKey`       | Shared encryption key, at least 32 characters | required without `existingSecret` |
+| `managed.admin.username`      | Bootstrap administrator                       | `admin`                           |
+| `managed.admin.password`      | Bootstrap password, at least 6 characters     | required without `existingSecret` |
+| `managed.admin.email`         | Bootstrap administrator email                 | `admin@example.com`               |
+| `autoscaling.enabled`         | Create an HPA                                 | `false`                           |
+| `podDisruptionBudget.enabled` | Protect availability during eviction          | `true`                            |
+| `service.type`                | Kubernetes Service type                       | `ClusterIP`                       |
+| `ingress.enabled`             | Create an Ingress                             | `false`                           |
 
 ## Upgrade
 
@@ -145,9 +157,10 @@ the migrated deployment has been verified.
 helm upgrade gocron gocron/gocron --reuse-values
 ```
 
-Generated secrets are retained across upgrades. Config or Secret changes alter
-the Deployment checksum and trigger a rolling update. Database schema changes
-run once under the database bootstrap lock before each Pod joins the service.
+Use `--reuse-values` and keep runtime secrets stable across upgrades. Config or
+Secret changes alter the Deployment checksum and trigger a rolling update.
+Database schema changes run once under the database bootstrap lock before each
+Pod joins the service.
 
 ## Uninstall
 

--- a/docs/en/guide/quick-start.md
+++ b/docs/en/guide/quick-start.md
@@ -10,25 +10,26 @@ This guide will help you quickly deploy and run gocron.
 
 ## Database Support
 
-| Deployment Method | MySQL | PostgreSQL | SQLite |
-|-------------------|-------|------------|--------|
-| Docker Deployment | ✅ Supported | ✅ Supported | ✅ Supported |
-| Kubernetes Deployment | ✅ Supported | ✅ Supported | ❌ Not supported |
-| Binary Deployment | ✅ Supported | ✅ Supported | ✅ Supported |
-| Development Environment | ✅ Supported | ✅ Supported | ✅ Supported |
+| Deployment Method       | MySQL        | PostgreSQL   | SQLite           |
+| ----------------------- | ------------ | ------------ | ---------------- |
+| Docker Deployment       | ✅ Supported | ✅ Supported | ✅ Supported     |
+| Kubernetes Deployment   | ✅ Supported | ✅ Supported | ❌ Not supported |
+| Binary Deployment       | ✅ Supported | ✅ Supported | ✅ Supported     |
+| Development Environment | ✅ Supported | ✅ Supported | ✅ Supported     |
 
 ::: tip Note
+
 - The managed Kubernetes Chart requires MySQL or PostgreSQL so every Pod can remain stateless and horizontally scalable. Other deployment methods retain pure-Go SQLite support.
 - **Production Recommendation**: Use MySQL or PostgreSQL for better performance and distributed deployment support
-:::
+  :::
 
 ## Choosing a Deployment Method
 
-| Scenario | Recommended |
-|----------|-------------|
+| Scenario                          | Recommended            |
+| --------------------------------- | ---------------------- |
 | Production, single / few machines | **Binary** (preferred) |
-| Production, Kubernetes cluster | Helm Chart |
-| Local evaluation, testing | Docker Compose |
+| Production, Kubernetes cluster    | Helm Chart             |
+| Local evaluation, testing         | Docker Compose         |
 
 gocron compiles into a single, dependency-free static binary (pure Go SQLite, no CGO), so binary deployment is the lightest and best-fitting option for single-machine production.
 
@@ -41,6 +42,7 @@ Suitable for production environments, supports all databases (including SQLite).
 Visit [GitHub Releases](https://github.com/gocronx-team/gocron/releases) to download the latest version.
 
 Choose the package for your platform:
+
 - Linux: `gocron-linux-amd64.tar.gz` or `gocron-linux-arm64.tar.gz`
 - macOS: `gocron-darwin-amd64.tar.gz` or `gocron-darwin-arm64.tar.gz`
 - Windows: `gocron-windows-amd64.zip` or `gocron-windows-arm64.zip`
@@ -136,10 +138,11 @@ docker compose up -d
 - Password: `admin123`
 
 ::: tip Tip
+
 - Docker Compose only deploys the gocron management server
 - Task nodes (gocron-node) need to be installed separately
 - See [Agent Auto-Registration](./agent-registration) for installing task nodes
-:::
+  :::
 
 ## Kubernetes Deployment (Helm)
 
@@ -168,7 +171,10 @@ helm upgrade gocron gocron/gocron --reuse-values \
   --set db.port=3306 \
   --set db.user=gocron \
   --set db.password=your_password \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 
 # PostgreSQL (the database must already exist)
 helm install gocron gocron/gocron \
@@ -177,13 +183,16 @@ helm install gocron gocron/gocron \
   --set db.port=5432 \
   --set db.user=gocron \
   --set db.password=your_password \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 ```
 
 ### Configure Ingress
 
 ```bash
-helm install gocron gocron/gocron \
+helm upgrade gocron gocron/gocron --reuse-values \
   --set ingress.enabled=true \
   --set 'ingress.hosts[0].host=gocron.example.com' \
   --set 'ingress.hosts[0].paths[0].path=/' \

--- a/docs/zh/guide/high-availability.md
+++ b/docs/zh/guide/high-availability.md
@@ -37,6 +37,7 @@ scp -r .gocron/conf/ user@node2:/path/to/gocron/.gocron/conf/
 ```
 
 该目录包含：
+
 - `app.ini` — 数据库和应用配置
 - `install.lock` — 标记安装完成
 - `.version` — 当前应用版本
@@ -95,7 +96,10 @@ helm install gocron gocron/gocron \
   --set db.port=5432 \
   --set db.user=gocron \
   --set db.password=replace-me \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 ```
 
 已有 Secret、扩容、HPA、Ingress 和管理员初始化配置请参考

--- a/docs/zh/guide/kubernetes.md
+++ b/docs/zh/guide/kubernetes.md
@@ -32,6 +32,14 @@ db:
   user: gocron
   password: replace-me
   database: gocron
+
+managed:
+  authSecret: replace-with-at-least-32-random-characters
+  encryptionKey: replace-with-another-32-random-characters
+  admin:
+    username: admin
+    password: replace-with-a-strong-admin-password
+    email: admin@example.com
 ```
 
 ```bash
@@ -41,8 +49,9 @@ helm install gocron gocron/gocron -f values-gocron.yaml
 数据库必须提前创建。首次启动时，各副本通过数据库 advisory lock 协调；一个 Pod
 创建表结构和管理员，其他 Pod 等待初始化完成，然后使用同一份配置启动。
 
-Kubernetes 部署不会显示 Web 安装向导。默认管理员为 `admin`，自动生成的密码保存在
-Release Secret 中：
+Kubernetes 部署不会显示 Web 安装向导。当 Chart 管理运行时 Secret 时，必须显式填写
+上面的四项敏感配置，使模板渲染结果稳定，并兼容 KubeVision 这类带预览确认的控制台。
+配置的管理员密码保存在 Release Secret 中：
 
 ```bash
 kubectl get secret gocron -o jsonpath='{.data.admin-password}' | base64 -d; echo
@@ -108,23 +117,25 @@ Chart 默认启用 PodDisruptionBudget，并配置优先跨节点分散 Pod 的�
 
 ## 配置项
 
-| 参数 | 说明 | 默认值 |
-|---|---|---|
-| `replicaCount` | 初始 Pod 数量 | `2` |
-| `db.engine` | `mysql` 或 `postgres` | `postgres` |
-| `db.host` | 稳定的数据库访问地址 | 必填 |
-| `db.port` | 数据库端口 | `5432` |
-| `db.user` | 数据库用户 | `gocron` |
-| `db.password` | Chart 管理 Secret 时使用的数据库密码 | 首次安装必填 |
-| `db.database` | 已存在的数据库名称 | `gocron` |
-| `managed.existingSecret` | 已存在的运行时 Secret | `""` |
-| `managed.admin.username` | 初始化管理员 | `admin` |
-| `managed.admin.password` | 初始化密码，为空时自动生成 | `""` |
-| `managed.admin.email` | 初始化管理员邮箱 | `admin@example.com` |
-| `autoscaling.enabled` | 创建 HPA | `false` |
-| `podDisruptionBudget.enabled` | 在驱逐期间保护可用性 | `true` |
-| `service.type` | Kubernetes Service 类型 | `ClusterIP` |
-| `ingress.enabled` | 创建 Ingress | `false` |
+| 参数                          | 说明                                 | 默认值                         |
+| ----------------------------- | ------------------------------------ | ------------------------------ |
+| `replicaCount`                | 初始 Pod 数量                        | `2`                            |
+| `db.engine`                   | `mysql` 或 `postgres`                | `postgres`                     |
+| `db.host`                     | 稳定的数据库访问地址                 | 必填                           |
+| `db.port`                     | 数据库端口                           | `5432`                         |
+| `db.user`                     | 数据库用户                           | `gocron`                       |
+| `db.password`                 | Chart 管理 Secret 时使用的数据库密码 | 必填                           |
+| `db.database`                 | 已存在的数据库名称                   | `gocron`                       |
+| `managed.existingSecret`      | 已存在的运行时 Secret                | `""`                           |
+| `managed.authSecret`          | 共享 JWT 密钥，至少 32 个字符        | 未配置 `existingSecret` 时必填 |
+| `managed.encryptionKey`       | 共享加密密钥，至少 32 个字符         | 未配置 `existingSecret` 时必填 |
+| `managed.admin.username`      | 初始化管理员                         | `admin`                        |
+| `managed.admin.password`      | 初始化密码，至少 6 个字符            | 未配置 `existingSecret` 时必填 |
+| `managed.admin.email`         | 初始化管理员邮箱                     | `admin@example.com`            |
+| `autoscaling.enabled`         | 创建 HPA                             | `false`                        |
+| `podDisruptionBudget.enabled` | 在驱逐期间保护可用性                 | `true`                         |
+| `service.type`                | Kubernetes Service 类型              | `ClusterIP`                    |
+| `ingress.enabled`             | 创建 Ingress                         | `false`                        |
 
 ## 升级
 
@@ -138,8 +149,9 @@ Chart 0.2.0 移除了 Kubernetes SQLite 和应用 PVC。不要直接升级使用
 helm upgrade gocron gocron/gocron --reuse-values
 ```
 
-自动生成的密钥会在升级时保留。ConfigMap 或 Secret 发生变化时，Deployment checksum
-会触发滚动更新。数据库结构升级会在数据库初始化锁内执行一次，完成后 Pod 才加入服务。
+升级时使用 `--reuse-values` 并保持运行时密钥不变。ConfigMap 或 Secret 发生变化时，
+Deployment checksum 会触发滚动更新。数据库结构升级会在数据库初始化锁内执行一次，
+完成后 Pod 才加入服务。
 
 ## 卸载
 

--- a/docs/zh/guide/quick-start.md
+++ b/docs/zh/guide/quick-start.md
@@ -10,25 +10,26 @@
 
 ## 数据库支持说明
 
-| 部署方式 | MySQL | PostgreSQL | SQLite |
-|---------|-------|------------|--------|
-| Docker 部署 | ✅ 支持 | ✅ 支持 | ✅ 支持 |
-| Kubernetes 部署 | ✅ 支持 | ✅ 支持 | ❌ 不支持 |
-| 二进制部署 | ✅ 支持 | ✅ 支持 | ✅ 支持 |
-| 开发环境 | ✅ 支持 | ✅ 支持 | ✅ 支持 |
+| 部署方式        | MySQL   | PostgreSQL | SQLite    |
+| --------------- | ------- | ---------- | --------- |
+| Docker 部署     | ✅ 支持 | ✅ 支持    | ✅ 支持   |
+| Kubernetes 部署 | ✅ 支持 | ✅ 支持    | ❌ 不支持 |
+| 二进制部署      | ✅ 支持 | ✅ 支持    | ✅ 支持   |
+| 开发环境        | ✅ 支持 | ✅ 支持    | ✅ 支持   |
 
 ::: tip 提示
+
 - Kubernetes 托管 Chart 要求使用 MySQL 或 PostgreSQL，确保每个 Pod 无状态并可横向扩容；其他部署方式继续支持纯 Go SQLite
 - **生产环境推荐**：使用 MySQL 或 PostgreSQL，性能更好，支持分布式部署
-:::
+  :::
 
 ## 部署方式怎么选
 
-| 场景 | 推荐方式 |
-|------|---------|
-| 生产环境、单机/少量机器 | **二进制**（首选） |
-| 生产环境、Kubernetes 集群 | Helm Chart |
-| 本地快速体验、测试 | Docker Compose |
+| 场景                      | 推荐方式           |
+| ------------------------- | ------------------ |
+| 生产环境、单机/少量机器   | **二进制**（首选） |
+| 生产环境、Kubernetes 集群 | Helm Chart         |
+| 本地快速体验、测试        | Docker Compose     |
 
 gocron 编译为零依赖的静态单文件（纯 Go SQLite，无需 CGO），因此二进制部署最轻量、最贴合其形态，是生产单机部署的首选。
 
@@ -41,6 +42,7 @@ gocron 编译为零依赖的静态单文件（纯 Go SQLite，无需 CGO），�
 访问 [GitHub Releases](https://github.com/gocronx-team/gocron/releases) 下载最新版本的安装包。
 
 选择对应平台的包：
+
 - Linux: `gocron-linux-amd64.tar.gz` 或 `gocron-linux-arm64.tar.gz`
 - macOS: `gocron-darwin-amd64.tar.gz` 或 `gocron-darwin-arm64.tar.gz`
 - Windows: `gocron-windows-amd64.zip` 或 `gocron-windows-arm64.zip`
@@ -136,10 +138,11 @@ docker compose up -d
 - 密码：`admin123`
 
 ::: tip 提示
+
 - Docker Compose 仅部署 gocron 管理端
 - 任务节点（gocron-node）需要单独安装部署
 - 请参考 [Agent 自动注册](./agent-registration) 章节安装任务节点
-:::
+  :::
 
 ## Kubernetes 部署（Helm）
 
@@ -167,7 +170,10 @@ helm upgrade gocron gocron/gocron --reuse-values \
   --set db.port=3306 \
   --set db.user=gocron \
   --set db.password=your_password \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 
 # 使用 PostgreSQL（数据库必须提前创建）
 helm install gocron gocron/gocron \
@@ -176,13 +182,16 @@ helm install gocron gocron/gocron \
   --set db.port=5432 \
   --set db.user=gocron \
   --set db.password=your_password \
-  --set db.database=gocron
+  --set db.database=gocron \
+  --set managed.authSecret=replace-with-at-least-32-random-characters \
+  --set managed.encryptionKey=replace-with-another-32-random-characters \
+  --set managed.admin.password=replace-with-a-strong-admin-password
 ```
 
 ### 配置 Ingress
 
 ```bash
-helm install gocron gocron/gocron \
+helm upgrade gocron gocron/gocron --reuse-values \
   --set ingress.enabled=true \
   --set 'ingress.hosts[0].host=gocron.example.com' \
   --set 'ingress.hosts[0].paths[0].path=/' \

--- a/helm/gocron/Chart.yaml
+++ b/helm/gocron/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: gocron
 description: Horizontally scalable gocron deployment with database-backed leader election
 type: application
-kubeVersion: ">=1.23.0-0"
-version: 0.2.0
-appVersion: "1.11.0"
+kubeVersion: '>=1.23.0-0'
+version: 0.2.1
+appVersion: '1.11.0'
 keywords:
   - cron
   - scheduler

--- a/helm/gocron/templates/NOTES.txt
+++ b/helm/gocron/templates/NOTES.txt
@@ -5,7 +5,7 @@ Only the database-elected leader runs scheduled tasks.
 
 {{- if not .Values.managed.existingSecret }}
 Initial administrator: {{ .Values.managed.admin.username }}
-Retrieve the generated password with:
+Retrieve the configured password with:
   kubectl get secret {{ include "gocron.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.managed.secretKeys.adminPassword }}}' | base64 -d; echo
 {{- end }}
 

--- a/helm/gocron/templates/_helpers.tpl
+++ b/helm/gocron/templates/_helpers.tpl
@@ -72,9 +72,19 @@ Image tag
 {{- if not .Values.db.host -}}
 {{- fail "db.host is required" -}}
 {{- end -}}
-{{- $currentSecret := lookup "v1" "Secret" .Release.Namespace (include "gocron.fullname" .) -}}
-{{- if and (not .Values.managed.existingSecret) (not .Values.db.password) (not $currentSecret) -}}
+{{- if not .Values.managed.existingSecret -}}
+{{- if not .Values.db.password -}}
 {{- fail "db.password or managed.existingSecret is required" -}}
+{{- end -}}
+{{- if lt (len .Values.managed.authSecret) 32 -}}
+{{- fail "managed.authSecret must contain at least 32 characters when managed.existingSecret is empty" -}}
+{{- end -}}
+{{- if lt (len .Values.managed.encryptionKey) 32 -}}
+{{- fail "managed.encryptionKey must contain at least 32 characters when managed.existingSecret is empty" -}}
+{{- end -}}
+{{- if lt (len .Values.managed.admin.password) 6 -}}
+{{- fail "managed.admin.password must contain at least 6 characters when managed.existingSecret is empty" -}}
+{{- end -}}
 {{- end -}}
 {{- if lt (int .Values.replicaCount) 1 -}}
 {{- fail "replicaCount must be at least 1" -}}

--- a/helm/gocron/templates/secret.yaml
+++ b/helm/gocron/templates/secret.yaml
@@ -1,25 +1,5 @@
 {{- if not .Values.managed.existingSecret }}
 {{- $name := include "gocron.fullname" . }}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
-{{- $databasePassword := .Values.db.password }}
-{{- $authSecret := .Values.managed.authSecret }}
-{{- $encryptionKey := .Values.managed.encryptionKey }}
-{{- $adminPassword := .Values.managed.admin.password }}
-{{- if and (not $databasePassword) $existing }}
-{{- $databasePassword = (index $existing.data .Values.managed.secretKeys.databasePassword | b64dec) }}
-{{- end }}
-{{- if and (not $authSecret) $existing }}
-{{- $authSecret = (index $existing.data .Values.managed.secretKeys.authSecret | b64dec) }}
-{{- end }}
-{{- if and (not $encryptionKey) $existing }}
-{{- $encryptionKey = (index $existing.data .Values.managed.secretKeys.encryptionKey | b64dec) }}
-{{- end }}
-{{- if and (not $adminPassword) $existing }}
-{{- $adminPassword = (index $existing.data .Values.managed.secretKeys.adminPassword | b64dec) }}
-{{- end }}
-{{- if not $authSecret }}{{- $authSecret = randAlphaNum 64 }}{{- end }}
-{{- if not $encryptionKey }}{{- $encryptionKey = randAlphaNum 64 }}{{- end }}
-{{- if not $adminPassword }}{{- $adminPassword = randAlphaNum 24 }}{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,8 +8,8 @@ metadata:
     {{- include "gocron.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ .Values.managed.secretKeys.databasePassword }}: {{ required "db.password is required for the first installation when managed.existingSecret is empty" $databasePassword | quote }}
-  {{ .Values.managed.secretKeys.authSecret }}: {{ $authSecret | quote }}
-  {{ .Values.managed.secretKeys.encryptionKey }}: {{ $encryptionKey | quote }}
-  {{ .Values.managed.secretKeys.adminPassword }}: {{ $adminPassword | quote }}
+  {{ .Values.managed.secretKeys.databasePassword }}: {{ .Values.db.password | quote }}
+  {{ .Values.managed.secretKeys.authSecret }}: {{ .Values.managed.authSecret | quote }}
+  {{ .Values.managed.secretKeys.encryptionKey }}: {{ .Values.managed.encryptionKey | quote }}
+  {{ .Values.managed.secretKeys.adminPassword }}: {{ .Values.managed.admin.password | quote }}
 {{- end }}

--- a/helm/gocron/values.yaml
+++ b/helm/gocron/values.yaml
@@ -2,23 +2,23 @@ replicaCount: 2
 
 image:
   repository: ghcr.io/gocronx-team/gocron
-  tag: "" # defaults to Chart appVersion
+  tag: '' # defaults to Chart appVersion
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 # Kubernetes deployments are managed and horizontally scalable. The database
 # must already exist and be reachable through one stable MySQL/PostgreSQL URL.
 db:
   engine: postgres
-  host: ""
+  host: ''
   port: 5432
   user: gocron
-  password: ""
+  password: ''
   database: gocron
-  prefix: ""
+  prefix: ''
   charset: utf8
   maxIdleConns: 5
   maxOpenConns: 100
@@ -26,23 +26,24 @@ db:
 managed:
   # Use an existing Secret instead of creating one. It must contain the keys
   # configured under secretKeys.
-  existingSecret: ""
+  existingSecret: ''
   secretKeys:
     databasePassword: db-password
     authSecret: auth-secret
     encryptionKey: encryption-key
     adminPassword: admin-password
-  # Empty values are generated once and retained across Helm upgrades.
-  authSecret: ""
-  encryptionKey: ""
+  # Required when existingSecret is empty. Keep these values stable across
+  # upgrades, or use an externally managed Secret instead.
+  authSecret: ''
+  encryptionKey: ''
   admin:
     username: admin
-    password: ""
+    password: ''
     email: admin@example.com
 
 app:
   name: gocron
-  allowIps: ""
+  allowIps: ''
   concurrencyQueue: 500
   enableTls: false
 
@@ -54,7 +55,7 @@ service:
 
 ingress:
   enabled: false
-  className: ""
+  className: ''
   annotations: {}
   hosts:
     - host: gocron.local
@@ -91,5 +92,5 @@ affinity: {}
 
 serviceAccount:
   create: true
-  name: ""
+  name: ''
   annotations: {}


### PR DESCRIPTION
## Summary
- remove Helm lookup and random template output so KubeVision can safely preview and install the chart
- require stable runtime secrets when the chart manages its Secret
- publish chart-only fixes after verifying the referenced application image exists
- document deterministic values in English and Chinese

## Verification
- Helm lint
- byte-identical repeated rendering
- existing Secret rendering
- lookup and random function rejection
- English and Chinese documentation build