### PR TITLE
fix(models): parenthesize keyword search OR to stop cross-task log leakage

### DIFF
--- a/internal/models/task_log.go
+++ b/internal/models/task_log.go
@@ -241,10 +241,12 @@ func (taskLog *TaskLog) parseWhere(query *gorm.DB, params CommonMap) {
 	}
 	// 关键字模糊搜索：匹配任务名或执行输出
 	// 参数化查询，% 通配在值侧拼接，无 SQL 注入风险
+	// OR 条件必须加括号，否则与 task_id/status 等过滤条件组合时，
+	// 会因 AND 优先级高于 OR 导致跨任务泄漏日志
 	keyword, ok := params["Keyword"]
 	if ok && keyword.(string) != "" {
 		like := "%" + keyword.(string) + "%"
-		query.Where("name LIKE ? OR result LIKE ?", like, like)
+		query.Where("(name LIKE ? OR result LIKE ?)", like, like)
 	}
 	// 按开始时间范围过滤（值为 time.Time，与统计查询一致，跨库稳妥）
 	if startTime, ok := params["StartTime"]; ok {


### PR DESCRIPTION
The keyword filter built `name LIKE ? OR result LIKE ?` without parentheses. Combined with task_id/status/time filters, AND binds tighter than OR, so the OR branch escaped the task filter and leaked matching logs from all tasks (the task-log page sends keyword + task_id together). Wrap the OR group in parentheses.