### PR TITLE
fix(models): persist notify_diagnosis in task and template create/update

### DIFF
--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -119,7 +119,7 @@ func (task *Task) Create() (insertId int, err error) {
 		"http_headers", "success_pattern", "secret_names", "timeout", "multi",
 		"retry_times", "retry_interval", "notify_status", "notify_type",
 		"notify_receiver_id", "notify_keyword", "notify_keyword_regex", "notify_keyword_exclude",
-		"tag", "log_retention_days", "remark", "status",
+		"notify_diagnosis", "tag", "log_retention_days", "remark", "status",
 	).Create(task)
 	if result.Error == nil {
 		insertId = task.Id
@@ -135,7 +135,7 @@ func (task *Task) UpdateBean(id int) (int64, error) {
 			"notify_type", "notify_receiver_id", "dependency_task_id",
 			"dependency_status", "tag", "http_method", "http_body",
 			"http_headers", "success_pattern", "secret_names", "notify_keyword", "notify_keyword_regex",
-			"notify_keyword_exclude", "log_retention_days").
+			"notify_keyword_exclude", "notify_diagnosis", "log_retention_days").
 		UpdateColumns(map[string]interface{}{
 			"name":                   task.Name,
 			"spec":                   task.Spec,

--- a/internal/models/task_template.go
+++ b/internal/models/task_template.go
@@ -53,7 +53,7 @@ func (t *TaskTemplate) UpdateBean(id int) (int64, error) {
 			"http_method", "http_body", "http_headers", "success_pattern",
 			"tag", "spec", "timeout", "multi", "retry_times", "retry_interval",
 			"timezone", "notify_status", "notify_type", "notify_keyword", "notify_keyword_regex",
-			"notify_keyword_exclude", "log_retention_days").
+			"notify_keyword_exclude", "notify_diagnosis", "log_retention_days").
 		UpdateColumns(map[string]interface{}{
 			"name":                   t.Name,
 			"description":            t.Description,


### PR DESCRIPTION
notify_diagnosis was missing from the Select() lists of Task.Create, Task.UpdateBean and TaskTemplate.UpdateBean while the update maps did set it, so GORM silently dropped the column and the AI diagnosis toggle never reached the database (always default 0, the feature never triggered).